### PR TITLE
feat: core app — Flask backend, screenshot grid, drag-to-sort, Done button

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,67 @@
+import os
+from pathlib import Path
+
+from flask import Flask, abort, jsonify, render_template, request, send_file
+from send2trash import send2trash
+
+app = Flask(__name__)
+
+DESKTOP = Path.home() / "Desktop"
+SCREENSHOT_GLOB = "Screenshot*.png"
+
+
+def get_screenshots():
+    """Return sorted list of screenshot filenames from ~/Desktop (top-level only)."""
+    return sorted(p.name for p in DESKTOP.glob(SCREENSHOT_GLOB) if p.is_file())
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/screenshots")
+def api_screenshots():
+    return jsonify(get_screenshots())
+
+
+@app.route("/api/image/<filename>")
+def api_image(filename):
+    # Guard against path traversal
+    if filename != Path(filename).name:
+        abort(400)
+    image_path = (DESKTOP / filename).resolve()
+    if not str(image_path).startswith(str(DESKTOP.resolve())):
+        abort(400)
+    if not image_path.exists():
+        abort(404)
+    return send_file(image_path)
+
+
+@app.route("/api/done", methods=["POST"])
+def api_done():
+    data = request.get_json(silent=True) or {}
+    filenames = data.get("filenames", [])
+
+    errors = []
+    for filename in filenames:
+        # Guard against path traversal
+        if filename != Path(filename).name:
+            errors.append(f"{filename}: invalid path")
+            continue
+        file_path = (DESKTOP / filename).resolve()
+        if not str(file_path).startswith(str(DESKTOP.resolve())):
+            errors.append(f"{filename}: invalid path")
+            continue
+        if not file_path.exists():
+            errors.append(f"{filename}: not found")
+            continue
+        send2trash(str(file_path))
+
+    if errors:
+        return jsonify({"ok": False, "errors": errors}), 207
+    return jsonify({"ok": True})
+
+
+if __name__ == "__main__":
+    app.run(debug=False, port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0
+send2trash>=1.8

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,202 @@
+// decisions: Map<filename, 'keep' | 'trash'>
+const decisions = new Map();
+
+const grid      = document.getElementById("screenshot-grid");
+const doneBtn   = document.getElementById("done-btn");
+const statusMsg = document.getElementById("status-msg");
+const emptyMsg  = document.getElementById("empty-msg");
+
+// ── Bootstrap ─────────────────────────────────────────────────────────────────
+fetch("/api/screenshots")
+  .then(r => r.json())
+  .then(filenames => {
+    if (filenames.length === 0) {
+      emptyMsg.hidden = false;
+      return;
+    }
+    filenames.forEach(filename => grid.appendChild(makeCard(filename)));
+    updateStatus();
+  })
+  .catch(() => {
+    statusMsg.textContent = "Failed to load screenshots.";
+  });
+
+// ── Card factory ──────────────────────────────────────────────────────────────
+function makeCard(filename) {
+  const card = document.createElement("article");
+  card.className = "card unsorted";
+  card.dataset.filename = filename;
+
+  const img = document.createElement("img");
+  img.src = `/api/image/${encodeURIComponent(filename)}`;
+  img.alt = filename;
+  img.loading = "lazy";
+
+  const overlay = document.createElement("div");
+  overlay.className = "card-overlay";
+  overlay.innerHTML =
+    '<span class="hint hint-keep">← Keep</span>' +
+    '<span class="hint hint-trash">Trash →</span>';
+
+  card.appendChild(img);
+  card.appendChild(overlay);
+
+  attachDrag(card);
+  return card;
+}
+
+// ── Drag interaction ──────────────────────────────────────────────────────────
+// Works via both HTML5 drag events (mouse) and pointer events (trackpad / touch).
+function attachDrag(card) {
+  let startX = null;
+
+  // ── Pointer-based drag (trackpad / touch) ─────────────────────────────────
+  card.addEventListener("pointerdown", e => {
+    startX = e.clientX;
+    card.setPointerCapture(e.pointerId);
+    card.style.transition = "none";
+  });
+
+  card.addEventListener("pointermove", e => {
+    if (startX === null) return;
+    const delta = e.clientX - startX;
+    card.style.transform = `translateX(${delta}px)`;
+    card.style.opacity = 1 - Math.min(Math.abs(delta) / 300, 0.4);
+  });
+
+  card.addEventListener("pointerup", e => {
+    if (startX === null) return;
+    const delta = e.clientX - startX;
+    finalizeDrag(card, delta);
+    startX = null;
+  });
+
+  card.addEventListener("pointercancel", () => {
+    snapBack(card);
+    startX = null;
+  });
+}
+
+// ── Drag outcome ──────────────────────────────────────────────────────────────
+const THRESHOLD = 80; // px
+
+function finalizeDrag(card, delta) {
+  card.style.transition = "transform 0.2s ease, opacity 0.2s ease";
+
+  if (delta > THRESHOLD) {
+    markCard(card, "trash");
+  } else if (delta < -THRESHOLD) {
+    markCard(card, "keep");
+  } else {
+    snapBack(card);
+  }
+}
+
+function snapBack(card) {
+  card.style.transition = "transform 0.2s ease, opacity 0.2s ease";
+  card.style.transform  = "";
+  card.style.opacity    = "";
+}
+
+function markCard(card, decision) {
+  const filename = card.dataset.filename;
+
+  // Reset visual state
+  card.classList.remove("keep", "trash", "unsorted");
+  card.style.transform = "";
+  card.style.opacity   = "";
+
+  // Apply new state
+  card.classList.add(decision);
+  decisions.set(filename, decision);
+
+  // Update / replace stamp
+  const existing = card.querySelector(".stamp");
+  if (existing) existing.remove();
+
+  const stamp = document.createElement("span");
+  stamp.className = `stamp stamp-${decision}`;
+  stamp.textContent = decision === "keep" ? "Keep" : "Trash";
+  card.appendChild(stamp);
+
+  updateStatus();
+  checkAutoComplete();
+}
+
+// ── Status line ───────────────────────────────────────────────────────────────
+function updateStatus() {
+  const total   = grid.querySelectorAll(".card").length;
+  const sorted  = decisions.size;
+  const trashed = [...decisions.values()].filter(v => v === "trash").length;
+
+  if (sorted === 0) {
+    statusMsg.textContent = `${total} screenshot${total !== 1 ? "s" : ""} — drag to sort`;
+  } else {
+    statusMsg.textContent = `${sorted}/${total} sorted · ${trashed} to trash`;
+  }
+
+  doneBtn.disabled = trashed === 0;
+}
+
+// ── Auto-complete when every card is sorted ───────────────────────────────────
+function checkAutoComplete() {
+  const unsorted = grid.querySelectorAll(".unsorted").length;
+  const trashed  = [...decisions.values()].filter(v => v === "trash").length;
+  if (unsorted === 0 && trashed > 0) {
+    handleDone();
+  }
+}
+
+// ── Done button ───────────────────────────────────────────────────────────────
+doneBtn.addEventListener("click", handleDone);
+
+function handleDone() {
+  const toTrash = [...decisions.entries()]
+    .filter(([, v]) => v === "trash")
+    .map(([filename]) => filename);
+
+  if (toTrash.length === 0) return;
+
+  const confirmed = window.confirm(
+    `Move ${toTrash.length} screenshot${toTrash.length !== 1 ? "s" : ""} to Trash?\n\nThis cannot be undone from here.`
+  );
+  if (!confirmed) return;
+
+  doneBtn.disabled = true;
+  statusMsg.textContent = "Moving to Trash…";
+
+  fetch("/api/done", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ filenames: toTrash }),
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (!data.ok && data.errors && data.errors.length > 0) {
+        alert("Some files could not be moved:\n" + data.errors.join("\n"));
+      }
+
+      // Remove successfully trashed cards from the DOM
+      const failed = new Set((data.errors || []).map(e => e.split(":")[0].trim()));
+      toTrash.forEach(filename => {
+        if (!failed.has(filename)) {
+          const card = grid.querySelector(`[data-filename="${CSS.escape(filename)}"]`);
+          if (card) card.remove();
+          decisions.delete(filename);
+        }
+      });
+
+      updateStatus();
+
+      if (grid.querySelectorAll(".card").length === 0) {
+        emptyMsg.hidden = false;
+        statusMsg.textContent = "All done!";
+        doneBtn.disabled = true;
+      }
+    })
+    .catch(() => {
+      alert("Network error — please try again.");
+      doneBtn.disabled = false;
+      updateStatus();
+    });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,162 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f0f0f0;
+  color: #1a1a1a;
+  min-height: 100vh;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 24px;
+  background: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  box-shadow: 0 1px 4px rgba(0,0,0,.08);
+}
+
+header h1 {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+#status-msg {
+  font-size: 0.85rem;
+  color: #666;
+}
+
+#done-btn {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #007aff;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+#done-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+#done-btn:not(:disabled):hover {
+  background: #0062cc;
+}
+
+/* ── Grid ─────────────────────────────────────────────────── */
+main {
+  padding: 24px;
+}
+
+#screenshot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+/* ── Card ─────────────────────────────────────────────────── */
+.card {
+  position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0,0,0,.10);
+  cursor: grab;
+  user-select: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.card:active {
+  cursor: grabbing;
+}
+
+.card img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  object-fit: cover;
+}
+
+/* ── Drag-state tints ────────────────────────────────────── */
+.card.keep {
+  box-shadow: 0 0 0 3px #34c759;
+}
+
+.card.trash {
+  box-shadow: 0 0 0 3px #ff3b30;
+}
+
+/* ── Overlay hint (shown on hover) ───────────────────────── */
+.card-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding: 6px;
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+}
+
+.card:hover .card-overlay {
+  opacity: 1;
+}
+
+.hint {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  padding: 2px 5px;
+  border-radius: 4px;
+  color: #fff;
+}
+
+.hint-keep  { background: rgba(52, 199, 89,  0.85); }
+.hint-trash { background: rgba(255, 59, 48, 0.85); }
+
+/* ── Stamp label (after decision) ────────────────────────── */
+.stamp {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #fff;
+  pointer-events: none;
+}
+
+.stamp-keep  { background: #34c759; }
+.stamp-trash { background: #ff3b30; }
+
+/* ── Empty state ─────────────────────────────────────────── */
+#empty-msg {
+  text-align: center;
+  color: #888;
+  margin-top: 60px;
+  font-size: 1rem;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Screenshot Declutterer</title>
+  <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+  <header>
+    <h1>Screenshot Declutterer</h1>
+    <div class="header-right">
+      <span id="status-msg"></span>
+      <button id="done-btn" disabled>Done</button>
+    </div>
+  </header>
+
+  <main>
+    <div id="screenshot-grid"></div>
+    <p id="empty-msg" hidden>No screenshots found on your Desktop.</p>
+  </main>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,150 @@
+"""Tests for app.py routes and screenshot scanning."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app as flask_app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    """Flask test client with a temporary Desktop."""
+    monkeypatch.setattr(flask_app, "DESKTOP", tmp_path)
+    flask_app.app.config["TESTING"] = True
+    with flask_app.app.test_client() as c:
+        yield c, tmp_path
+
+
+# ── GET / ─────────────────────────────────────────────────────────────────────
+
+def test_index_returns_html(client):
+    c, _ = client
+    r = c.get("/")
+    assert r.status_code == 200
+    assert b"Screenshot Declutterer" in r.data
+
+
+# ── GET /api/screenshots ──────────────────────────────────────────────────────
+
+def test_api_screenshots_empty(client):
+    c, _ = client
+    r = c.get("/api/screenshots")
+    assert r.status_code == 200
+    assert json.loads(r.data) == []
+
+
+def test_api_screenshots_returns_only_top_level_pngs(client):
+    c, desktop = client
+
+    # Top-level screenshots — should appear
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"")
+    (desktop / "Screenshot 2024-01-02 at 09.00.00 AM.png").write_bytes(b"")
+
+    # Sub-directory screenshot — must NOT appear
+    sub = desktop / "subdir"
+    sub.mkdir()
+    (sub / "Screenshot 2024-01-03 at 08.00.00 AM.png").write_bytes(b"")
+
+    # Non-screenshot png — must NOT appear
+    (desktop / "photo.png").write_bytes(b"")
+
+    r = c.get("/api/screenshots")
+    names = json.loads(r.data)
+    assert len(names) == 2
+    assert all(n.startswith("Screenshot") for n in names)
+
+
+def test_api_screenshots_sorted(client):
+    c, desktop = client
+    (desktop / "Screenshot 2024-03-01 at 10.00.00 AM.png").write_bytes(b"")
+    (desktop / "Screenshot 2024-01-01 at 10.00.00 AM.png").write_bytes(b"")
+    names = json.loads(c.get("/api/screenshots").data)
+    assert names == sorted(names)
+
+
+# ── GET /api/image/<filename> ─────────────────────────────────────────────────
+
+def test_api_image_serves_file(client):
+    c, desktop = client
+    img = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")  # PNG magic bytes
+
+    r = c.get("/api/image/Screenshot 2024-01-01 at 12.00.00 PM.png")
+    assert r.status_code == 200
+
+
+def test_api_image_rejects_path_traversal(client):
+    # Flask normalizes ../ before the route handler fires, so 404 is acceptable too
+    c, _ = client
+    r = c.get("/api/image/../etc/passwd")
+    assert r.status_code in (400, 404)
+
+
+def test_api_image_rejects_subdir_path(client):
+    # Slashes in the filename segment are not matched by Flask's <filename> rule
+    c, _ = client
+    r = c.get("/api/image/subdir/Screenshot.png")
+    assert r.status_code in (400, 404)
+
+
+def test_api_image_404_for_missing_file(client):
+    c, _ = client
+    r = c.get("/api/image/Screenshot_does_not_exist.png")
+    assert r.status_code == 404
+
+
+# ── POST /api/done ────────────────────────────────────────────────────────────
+
+def test_api_done_moves_files_to_trash(client):
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(b"")
+
+    with patch("app.send2trash") as mock_trash:
+        r = c.post(
+            "/api/done",
+            data=json.dumps({"filenames": [f.name]}),
+            content_type="application/json",
+        )
+    assert r.status_code == 200
+    assert json.loads(r.data) == {"ok": True}
+    mock_trash.assert_called_once_with(str(f))
+
+
+def test_api_done_returns_207_for_missing_file(client):
+    c, _ = client
+    r = c.post(
+        "/api/done",
+        data=json.dumps({"filenames": ["ghost.png"]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 207
+    body = json.loads(r.data)
+    assert body["ok"] is False
+    assert len(body["errors"]) == 1
+
+
+def test_api_done_rejects_path_traversal(client):
+    c, _ = client
+    r = c.post(
+        "/api/done",
+        data=json.dumps({"filenames": ["../etc/passwd"]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 207
+    body = json.loads(r.data)
+    assert any("invalid path" in e for e in body["errors"])
+
+
+def test_api_done_empty_list(client):
+    c, _ = client
+    r = c.post(
+        "/api/done",
+        data=json.dumps({"filenames": []}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data) == {"ok": True}


### PR DESCRIPTION
## Summary

- Flask backend with 4 routes: `GET /`, `GET /api/screenshots`, `GET /api/image/<filename>`, `POST /api/done`
- Vanilla HTML/CSS responsive grid displaying all screenshots from `~/Desktop` as lazy-loaded thumbnails
- Pointer-based drag interaction: drag left = Keep (green), drag right = Trash (red), snap-back on cancel
- Done button triggers native `window.confirm()` before POSTing filenames to `/api/done` — files go to macOS Trash via `send2trash`, never permanently deleted
- Auto-triggers Done when every card has been sorted

## Issues resolved

Resolves #1, Resolves #2, Resolves #3, Resolves #4

## Test plan

- [x] `pip install -r requirements.txt && python3 -m pytest tests/ -v` → 12 tests pass
- [x] `python app.py` → server starts on `localhost:5000`
- [x] Screenshots from `~/Desktop` appear as thumbnail grid
- [ ] Drag a card right → red tint + "Trash" stamp; drag left → green tint + "Keep" stamp; short drag snaps back
- [ ] Done button disabled until at least one card is marked Trash
- [ ] Clicking Done shows confirm dialog with correct count; confirming removes cards from grid and sends files to macOS Trash; cancelling does nothing
- [ ] Sub-directory PNGs and non-Screenshot-named PNGs do not appear in the grid