### PR TITLE
feat: polish — README, MIT license, auto-open browser

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Guruprasath
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# ss-dcl
+# Screenshot Declutterer
+
+A simple macOS tool to quickly sort and trash the screenshots cluttering your Desktop.
+
+## What it does
+
+Opens a local webpage showing all your Desktop screenshots as thumbnails. Drag a screenshot **left** to keep it, **right** to trash it. When you're done sorting, click **Done** (or let it auto-trigger) — you'll get a confirmation dialog before anything moves to the Trash. Files are never permanently deleted; they go to macOS Trash so you can recover them if needed.
+
+## Requirements
+
+- macOS
+- Python 3.9+
+
+## Install
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run
+
+```bash
+python app.py
+```
+
+Your browser opens automatically at `http://localhost:5000`.
+
+## How it works
+
+- Scans `~/Desktop` for files matching `Screenshot*.png` (top-level only)
+- Serves them via a local Flask server — nothing leaves your machine
+- Drag interaction is handled entirely in the browser with vanilla JavaScript
+- Trashing is done via [`send2trash`](https://github.com/arsenetar/send2trash), which uses the native macOS Trash
+
+## License
+
+MIT — see [LICENSE](LICENSE)

--- a/app.py
+++ b/app.py
@@ -1,4 +1,7 @@
 import os
+import threading
+import time
+import webbrowser
 from pathlib import Path
 
 from flask import Flask, abort, jsonify, render_template, request, send_file
@@ -63,5 +66,17 @@ def api_done():
     return jsonify({"ok": True})
 
 
+def _open_browser():
+    # Wait briefly for Flask to finish binding the port, then open the browser.
+    # Guard against Flask's reloader launching a second process.
+    if os.environ.get("WERKZEUG_RUN_MAIN") != "true":
+        time.sleep(1)
+        try:
+            webbrowser.open_new_tab("http://localhost:5000")
+        except Exception:
+            pass  # headless / CI environment — ignore
+
+
 if __name__ == "__main__":
+    threading.Thread(target=_open_browser, daemon=True).start()
     app.run(debug=False, port=5000)


### PR DESCRIPTION
## Summary

- `README.md` fully written: what it does, requirements, install, run, how it works, license
- `LICENSE` — MIT 2026, author Guruprasath
- `app.py` — browser opens automatically on `python app.py` via a daemonized thread with a 1-second startup delay; guarded with `WERKZEUG_RUN_MAIN` to prevent double-open from Flask's reloader

## Issues resolved

Resolves #5

## Test plan

- [ ] `python3 -m pytest tests/ -v` → 12 tests pass (no regressions)
- [ ] `python app.py` → browser opens at `http://localhost:5000` without prompting
- [ ] `LICENSE` present with MIT text
- [ ] `README.md` clone → install → run instructions are accurate end-to-end