### PR TITLE
fix: change default port to 5001 to avoid macOS AirPlay 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ uv sync
 uv run python app.py
 ```
 
-Your browser opens automatically at `http://localhost:5000`.
+Your browser opens automatically at `http://localhost:5001`.
 
 ## How it works
 

--- a/app.py
+++ b/app.py
@@ -73,9 +73,9 @@ def _open_browser():
     if os.environ.get("WERKZEUG_RUN_MAIN") != "true":
         time.sleep(1)
         with contextlib.suppress(Exception):
-            webbrowser.open_new_tab("http://localhost:5000")
+            webbrowser.open_new_tab("http://localhost:5001")
 
 
 if __name__ == "__main__":
     threading.Thread(target=_open_browser, daemon=True).start()
-    app.run(debug=False, port=5000)
+    app.run(debug=False, port=5001)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -242,7 +242,7 @@ def test_open_browser_opens_tab(monkeypatch):
 
     with patch("app.time.sleep"), patch("app.webbrowser") as mock_wb:
         flask_app._open_browser()
-    mock_wb.open_new_tab.assert_called_once_with("http://localhost:5000")
+    mock_wb.open_new_tab.assert_called_once_with("http://localhost:5001")
 
 
 def test_get_screenshots_returns_list(client):


### PR DESCRIPTION
## Summary

- Changed default port from `5000` → `5001` in `app.py`, `README.md`, and tests
- **Root cause**: macOS Monterey+ reserves port 5000 for AirPlay Receiver, which returns HTTP 403 to browsers hitting `localhost:5000`

Resolves #13

## Test plan

- [x] `uv run python app.py` — browser opens at `http://localhost:5001` without 403
- [x] `uv run pytest` — 20 tests pass
- [ ] All pre-commit hooks pass