### PR TITLE
fix: swap Trash/Keep columns, add global Undo button

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,12 +1,37 @@
+// ── State ─────────────────────────────────────────────────────────────────────
 // decisions: Map<filename, 'keep' | 'trash'>
 const decisions = new Map();
+const undoStack = []; // { filename, from, to }
 
-const grid      = document.getElementById("screenshot-grid");
+// ── DOM refs ─────────────────────────────────────────────────────────────────
+const cardsUnsorted = document.getElementById("cards-unsorted");
+const cardsTrash    = document.getElementById("cards-trash");
+const cardsKeep     = document.getElementById("cards-keep");
+
+const colUnsorted = document.getElementById("col-unsorted");
+const colTrash    = document.getElementById("col-trash");
+const colKeep     = document.getElementById("col-keep");
+
+const countUnsorted = document.getElementById("count-unsorted");
+const countTrash    = document.getElementById("count-trash");
+const countKeep     = document.getElementById("count-keep");
+
+const undoBtn   = document.getElementById("undo-btn");
 const doneBtn   = document.getElementById("done-btn");
 const statusMsg = document.getElementById("status-msg");
 const emptyMsg  = document.getElementById("empty-msg");
 
-// ── Bootstrap ─────────────────────────────────────────────────────────────────
+const lightbox    = document.getElementById("lightbox");
+const lightboxImg = document.getElementById("lightbox-img");
+
+const confirmModal = document.getElementById("confirm-modal");
+const modalTitle   = document.getElementById("modal-title");
+const modalCancel  = document.getElementById("modal-cancel");
+const modalConfirm = document.getElementById("modal-confirm");
+
+const columns = [colTrash, colUnsorted, colKeep];
+
+// ── Bootstrap ────────────────────────────────────────────────────────────────
 fetch("/api/screenshots")
   .then(r => r.json())
   .then(filenames => {
@@ -14,156 +39,280 @@ fetch("/api/screenshots")
       emptyMsg.hidden = false;
       return;
     }
-    filenames.forEach(filename => grid.appendChild(makeCard(filename)));
-    updateStatus();
+    filenames.forEach(f => cardsUnsorted.appendChild(makeCard(f, "unsorted")));
+    updateCounts();
   })
   .catch(() => {
     statusMsg.textContent = "Failed to load screenshots.";
   });
 
-// ── Card factory ──────────────────────────────────────────────────────────────
-function makeCard(filename) {
+// ── Card factory ─────────────────────────────────────────────────────────────
+function makeCard(filename, column) {
   const card = document.createElement("article");
-  card.className = "card unsorted";
+  card.className = "card";
   card.dataset.filename = filename;
+  card.draggable = true;
+  card.tabIndex = 0;
 
   const img = document.createElement("img");
   img.src = `/api/image/${encodeURIComponent(filename)}`;
   img.alt = filename;
   img.loading = "lazy";
 
-  const overlay = document.createElement("div");
-  overlay.className = "card-overlay";
-  overlay.innerHTML =
-    '<span class="hint hint-keep">← Keep</span>' +
-    '<span class="hint hint-trash">Trash →</span>';
+  const actions = document.createElement("div");
+  actions.className = "card-actions";
 
   card.appendChild(img);
-  card.appendChild(overlay);
+  card.appendChild(actions);
 
+  setCardActions(card, column);
   attachDrag(card);
+  attachPreview(card);
+  attachKeyboard(card);
+
   return card;
 }
 
-// ── Drag interaction ──────────────────────────────────────────────────────────
-// Works via both HTML5 drag events (mouse) and pointer events (trackpad / touch).
-function attachDrag(card) {
-  let startX = null;
+// ── Card action buttons ──────────────────────────────────────────────────────
+function setCardActions(card, column) {
+  const actions = card.querySelector(".card-actions");
+  actions.innerHTML = "";
 
-  // ── Pointer-based drag (trackpad / touch) ─────────────────────────────────
-  card.addEventListener("pointerdown", e => {
-    startX = e.clientX;
-    card.setPointerCapture(e.pointerId);
-    card.style.transition = "none";
-  });
-
-  card.addEventListener("pointermove", e => {
-    if (startX === null) return;
-    const delta = e.clientX - startX;
-    card.style.transform = `translateX(${delta}px)`;
-    card.style.opacity = 1 - Math.min(Math.abs(delta) / 300, 0.4);
-  });
-
-  card.addEventListener("pointerup", e => {
-    if (startX === null) return;
-    const delta = e.clientX - startX;
-    finalizeDrag(card, delta);
-    startX = null;
-  });
-
-  card.addEventListener("pointercancel", () => {
-    snapBack(card);
-    startX = null;
-  });
-}
-
-// ── Drag outcome ──────────────────────────────────────────────────────────────
-const THRESHOLD = 80; // px
-
-function finalizeDrag(card, delta) {
-  card.style.transition = "transform 0.2s ease, opacity 0.2s ease";
-
-  if (delta > THRESHOLD) {
-    markCard(card, "trash");
-  } else if (delta < -THRESHOLD) {
-    markCard(card, "keep");
+  if (column === "unsorted") {
+    const keepBtn = makeActionBtn("\u2190 Keep", "btn-keep", () => moveCard(card, "keep"));
+    const previewBtn = makeActionBtn("Preview", "btn-preview", () => openLightbox(card));
+    const trashBtn = makeActionBtn("Trash \u2192", "btn-trash", () => moveCard(card, "trash"));
+    actions.appendChild(keepBtn);
+    actions.appendChild(previewBtn);
+    actions.appendChild(trashBtn);
   } else {
-    snapBack(card);
+    const previewBtn = makeActionBtn("Preview", "btn-preview", () => openLightbox(card));
+    const undoBtn = makeActionBtn("\u21A9 Undo", "btn-undo", () => moveCard(card, "unsorted"));
+    actions.appendChild(previewBtn);
+    actions.appendChild(undoBtn);
   }
 }
 
-function snapBack(card) {
-  card.style.transition = "transform 0.2s ease, opacity 0.2s ease";
-  card.style.transform  = "";
-  card.style.opacity    = "";
+function makeActionBtn(label, cls, onClick) {
+  const btn = document.createElement("button");
+  btn.className = `action-btn ${cls}`;
+  btn.textContent = label;
+  btn.addEventListener("click", e => {
+    e.stopPropagation();
+    onClick();
+  });
+  return btn;
 }
 
-function markCard(card, decision) {
+// ── Move card between columns ────────────────────────────────────────────────
+function moveCard(card, toColumn) {
   const filename = card.dataset.filename;
+  const fromColumn = getCardColumn(card);
 
-  // Reset visual state
-  card.classList.remove("keep", "trash", "unsorted");
-  card.style.transform = "";
-  card.style.opacity   = "";
+  if (fromColumn === toColumn) return;
 
-  // Apply new state
-  card.classList.add(decision);
-  decisions.set(filename, decision);
-
-  // Update / replace stamp
-  const existing = card.querySelector(".stamp");
-  if (existing) existing.remove();
-
-  const stamp = document.createElement("span");
-  stamp.className = `stamp stamp-${decision}`;
-  stamp.textContent = decision === "keep" ? "Keep" : "Trash";
-  card.appendChild(stamp);
-
-  updateStatus();
-  checkAutoComplete();
-}
-
-// ── Status line ───────────────────────────────────────────────────────────────
-function updateStatus() {
-  const total   = grid.querySelectorAll(".card").length;
-  const sorted  = decisions.size;
-  const trashed = [...decisions.values()].filter(v => v === "trash").length;
-
-  if (sorted === 0) {
-    statusMsg.textContent = `${total} screenshot${total !== 1 ? "s" : ""} — drag to sort`;
+  // Update decisions map
+  if (toColumn === "unsorted") {
+    decisions.delete(filename);
   } else {
-    statusMsg.textContent = `${sorted}/${total} sorted · ${trashed} to trash`;
+    decisions.set(filename, toColumn);
   }
 
-  doneBtn.disabled = trashed === 0;
-}
+  // Push undo
+  undoStack.push({ filename, from: fromColumn, to: toColumn });
 
-// ── Auto-complete when every card is sorted ───────────────────────────────────
-function checkAutoComplete() {
-  const unsorted = grid.querySelectorAll(".unsorted").length;
-  const trashed  = [...decisions.values()].filter(v => v === "trash").length;
-  if (unsorted === 0 && trashed > 0) {
-    handleDone();
+  // Move DOM
+  const target = toColumn === "trash" ? cardsTrash
+               : toColumn === "keep"  ? cardsKeep
+               : cardsUnsorted;
+
+  if (toColumn === "unsorted") {
+    target.prepend(card);
+  } else {
+    target.prepend(card);
   }
+
+  setCardActions(card, toColumn);
+  updateCounts();
 }
 
-// ── Done button ───────────────────────────────────────────────────────────────
-doneBtn.addEventListener("click", handleDone);
+function getCardColumn(card) {
+  if (cardsTrash.contains(card)) return "trash";
+  if (cardsKeep.contains(card)) return "keep";
+  return "unsorted";
+}
 
-function handleDone() {
-  const toTrash = [...decisions.entries()]
-    .filter(([, v]) => v === "trash")
-    .map(([filename]) => filename);
+// ── HTML5 Drag & Drop ────────────────────────────────────────────────────────
+let draggedCard = null;
+
+function attachDrag(card) {
+  card.addEventListener("dragstart", e => {
+    draggedCard = card;
+    card.classList.add("dragging");
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", card.dataset.filename);
+  });
+
+  card.addEventListener("dragend", () => {
+    card.classList.remove("dragging");
+    draggedCard = null;
+    columns.forEach(c => c.classList.remove("drag-over"));
+  });
+}
+
+// Column drop zones
+columns.forEach(col => {
+  col.addEventListener("dragover", e => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    col.classList.add("drag-over");
+  });
+
+  col.addEventListener("dragleave", e => {
+    if (!col.contains(e.relatedTarget)) {
+      col.classList.remove("drag-over");
+    }
+  });
+
+  col.addEventListener("drop", e => {
+    e.preventDefault();
+    col.classList.remove("drag-over");
+    if (!draggedCard) return;
+
+    const targetColumn = col.dataset.column;
+    moveCard(draggedCard, targetColumn);
+  });
+});
+
+// ── Preview / Lightbox ───────────────────────────────────────────────────────
+function attachPreview(card) {
+  card.addEventListener("dblclick", e => {
+    e.preventDefault();
+    openLightbox(card);
+  });
+}
+
+function openLightbox(card) {
+  const filename = card.dataset.filename;
+  lightboxImg.src = `/api/image/${encodeURIComponent(filename)}`;
+  lightboxImg.alt = filename;
+  lightbox.hidden = false;
+}
+
+function closeLightbox() {
+  lightbox.hidden = true;
+  lightboxImg.src = "";
+}
+
+document.getElementById("lightbox-close").addEventListener("click", closeLightbox);
+document.querySelector(".lightbox-backdrop").addEventListener("click", closeLightbox);
+
+// ── Keyboard shortcuts ───────────────────────────────────────────────────────
+function attachKeyboard(card) {
+  card.addEventListener("keydown", e => {
+    const col = getCardColumn(card);
+    if (col === "unsorted") {
+      if (e.key === "ArrowLeft") { e.preventDefault(); moveCard(card, "keep"); }
+      if (e.key === "ArrowRight") { e.preventDefault(); moveCard(card, "trash"); }
+    } else {
+      if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+        e.preventDefault();
+        moveCard(card, "unsorted");
+      }
+    }
+  });
+}
+
+document.addEventListener("keydown", e => {
+  // Esc closes lightbox
+  if (e.key === "Escape") {
+    if (!lightbox.hidden) { closeLightbox(); return; }
+    if (!confirmModal.hidden) { closeModal(); return; }
+  }
+
+  // Cmd/Ctrl+Z = undo
+  if ((e.metaKey || e.ctrlKey) && e.key === "z") {
+    e.preventDefault();
+    performUndo();
+  }
+});
+
+// ── Undo ─────────────────────────────────────────────────────────────────────
+undoBtn.addEventListener("click", () => performUndo());
+function performUndo() {
+  if (undoStack.length === 0) return;
+  const action = undoStack.pop();
+  const card = document.querySelector(`[data-filename="${CSS.escape(action.filename)}"]`);
+  if (!card) return;
+
+  // Move back without pushing to undo stack
+  const fromColumn = action.from;
+  const filename = action.filename;
+
+  if (fromColumn === "unsorted") {
+    decisions.delete(filename);
+  } else {
+    decisions.set(filename, fromColumn);
+  }
+
+  const target = fromColumn === "trash" ? cardsTrash
+               : fromColumn === "keep"  ? cardsKeep
+               : cardsUnsorted;
+  target.prepend(card);
+
+  setCardActions(card, fromColumn);
+  updateCounts();
+}
+
+// ── Counts & status ──────────────────────────────────────────────────────────
+function updateCounts() {
+  const nUnsorted = cardsUnsorted.querySelectorAll(".card").length;
+  const nTrash    = cardsTrash.querySelectorAll(".card").length;
+  const nKeep     = cardsKeep.querySelectorAll(".card").length;
+  const total     = nUnsorted + nTrash + nKeep;
+
+  countUnsorted.textContent = nUnsorted;
+  countTrash.textContent    = nTrash;
+  countKeep.textContent     = nKeep;
+
+  if (nTrash + nKeep === 0) {
+    statusMsg.textContent = `${total} screenshot${total !== 1 ? "s" : ""} \u2014 drag to sort`;
+  } else {
+    statusMsg.textContent = `${nTrash + nKeep}/${total} sorted \u00B7 ${nTrash} to trash`;
+  }
+
+  undoBtn.disabled = undoStack.length === 0;
+  doneBtn.disabled = nTrash === 0;
+}
+
+// ── Done button / modal ──────────────────────────────────────────────────────
+doneBtn.addEventListener("click", () => {
+  const nTrash = cardsTrash.querySelectorAll(".card").length;
+  if (nTrash === 0) return;
+
+  modalTitle.textContent = `Move ${nTrash} screenshot${nTrash !== 1 ? "s" : ""} to Trash?`;
+  confirmModal.hidden = false;
+});
+
+function closeModal() {
+  confirmModal.hidden = true;
+}
+
+modalCancel.addEventListener("click", closeModal);
+confirmModal.addEventListener("click", e => {
+  if (e.target === confirmModal) closeModal();
+});
+
+modalConfirm.addEventListener("click", () => {
+  closeModal();
+
+  const toTrash = [...cardsTrash.querySelectorAll(".card")]
+    .map(c => c.dataset.filename);
 
   if (toTrash.length === 0) return;
 
-  const confirmed = window.confirm(
-    `Move ${toTrash.length} screenshot${toTrash.length !== 1 ? "s" : ""} to Trash?\n\nThis cannot be undone from here.`
-  );
-  if (!confirmed) return;
-
   doneBtn.disabled = true;
-  statusMsg.textContent = "Moving to Trash…";
+  statusMsg.textContent = "Moving to Trash\u2026";
 
   fetch("/api/done", {
     method: "POST",
@@ -176,27 +325,30 @@ function handleDone() {
         alert("Some files could not be moved:\n" + data.errors.join("\n"));
       }
 
-      // Remove successfully trashed cards from the DOM
       const failed = new Set((data.errors || []).map(e => e.split(":")[0].trim()));
       toTrash.forEach(filename => {
         if (!failed.has(filename)) {
-          const card = grid.querySelector(`[data-filename="${CSS.escape(filename)}"]`);
+          const card = cardsTrash.querySelector(`[data-filename="${CSS.escape(filename)}"]`);
           if (card) card.remove();
           decisions.delete(filename);
         }
       });
 
-      updateStatus();
+      // Clear undo stack for trashed files
+      undoStack.length = 0;
 
-      if (grid.querySelectorAll(".card").length === 0) {
+      updateCounts();
+
+      const remaining = document.querySelectorAll(".card").length;
+      if (remaining === 0) {
         emptyMsg.hidden = false;
         statusMsg.textContent = "All done!";
         doneBtn.disabled = true;
       }
     })
     .catch(() => {
-      alert("Network error — please try again.");
+      alert("Network error \u2014 please try again.");
       doneBtn.disabled = false;
-      updateStatus();
+      updateCounts();
     });
-}
+});

--- a/static/style.css
+++ b/static/style.css
@@ -6,9 +6,12 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #f0f0f0;
+  background: #f5f5f7;
   color: #1a1a1a;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 /* ── Header ──────────────────────────────────────────────── */
@@ -22,7 +25,8 @@ header {
   padding: 12px 24px;
   background: #fff;
   border-bottom: 1px solid #e0e0e0;
-  box-shadow: 0 1px 4px rgba(0,0,0,.08);
+  box-shadow: 0 1px 4px rgba(0,0,0,.06);
+  flex-shrink: 0;
 }
 
 header h1 {
@@ -33,7 +37,7 @@ header h1 {
 .header-right {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 
 #status-msg {
@@ -41,8 +45,29 @@ header h1 {
   color: #666;
 }
 
+#undo-btn {
+  padding: 8px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #8e8e93;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+#undo-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+#undo-btn:not(:disabled):hover {
+  background: #6e6e73;
+}
+
 #done-btn {
-  padding: 8px 20px;
+  padding: 8px 22px;
   border: none;
   border-radius: 8px;
   background: #007aff;
@@ -62,96 +87,222 @@ header h1 {
   background: #0062cc;
 }
 
-/* ── Grid ─────────────────────────────────────────────────── */
-main {
-  padding: 24px;
+/* ── Kanban layout ───────────────────────────────────────── */
+.kanban {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  gap: 0;
 }
 
-#screenshot-grid {
+.column {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-right: 1px solid #e5e5e5;
+}
+
+.column:last-child {
+  border-right: none;
+}
+
+.column-trash,
+.column-keep {
+  width: 22%;
+  min-width: 180px;
+  background: #fafafa;
+}
+
+.column-unsorted {
+  flex: 1;
+  background: #f5f5f7;
+}
+
+/* ── Column header ───────────────────────────────────────── */
+.column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid #e5e5e5;
+  flex-shrink: 0;
+}
+
+.column-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #888;
+}
+
+.column-trash .column-title { color: #ff3b30; }
+.column-keep  .column-title { color: #34c759; }
+
+.column-count {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: #eee;
+  color: #666;
+}
+
+.column-trash .column-count { background: #fff0f0; color: #ff3b30; }
+.column-keep  .column-count { background: #f0fff4; color: #34c759; }
+
+/* ── Column cards container ──────────────────────────────── */
+.column-cards {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  min-height: 0;
+}
+
+.column-unsorted .column-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 12px;
+  align-content: start;
 }
 
-/* ── Card ─────────────────────────────────────────────────── */
+.column-trash .column-cards,
+.column-keep .column-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Drop zone highlight ─────────────────────────────────── */
+.column.drag-over {
+  background: rgba(0, 122, 255, 0.04);
+}
+
+.column-trash.drag-over {
+  background: rgba(255, 59, 48, 0.06);
+}
+
+.column-trash.drag-over .column-cards {
+  outline: 2px dashed rgba(255, 59, 48, 0.35);
+  outline-offset: -4px;
+  border-radius: 8px;
+}
+
+.column-keep.drag-over {
+  background: rgba(52, 199, 89, 0.06);
+}
+
+.column-keep.drag-over .column-cards {
+  outline: 2px dashed rgba(52, 199, 89, 0.35);
+  outline-offset: -4px;
+  border-radius: 8px;
+}
+
+/* ── Card ────────────────────────────────────────────────── */
 .card {
   position: relative;
-  border-radius: 8px;
-  overflow: hidden;
+  border-radius: 10px;
+  overflow: clip;
   background: #fff;
-  box-shadow: 0 1px 4px rgba(0,0,0,.10);
+  box-shadow: 0 1px 6px rgba(0,0,0,.08);
   cursor: grab;
   user-select: none;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.card:hover {
+  box-shadow: 0 3px 12px rgba(0,0,0,.14);
 }
 
 .card:active {
   cursor: grabbing;
 }
 
+.card.dragging {
+  opacity: 0.5;
+  transform: scale(0.96);
+}
+
 .card img {
   display: block;
   width: 100%;
-  aspect-ratio: 9 / 16;
+  aspect-ratio: 16 / 9;
   object-fit: cover;
+  pointer-events: none;
 }
 
-/* ── Drag-state tints ────────────────────────────────────── */
-.card.keep {
-  box-shadow: 0 0 0 3px #34c759;
-}
-
-.card.trash {
-  box-shadow: 0 0 0 3px #ff3b30;
-}
-
-/* ── Overlay hint (shown on hover) ───────────────────────── */
-.card-overlay {
+/* ── Card action buttons overlay ─────────────────────────── */
+.card-actions {
   position: absolute;
   inset: 0;
   display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  padding: 6px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity 0.15s;
   pointer-events: none;
+  background: rgba(0, 0, 0, 0.25);
 }
 
-.card:hover .card-overlay {
+.card:hover .card-actions {
   opacity: 1;
+  pointer-events: auto;
 }
 
-.hint {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .04em;
-  padding: 2px 5px;
-  border-radius: 4px;
+.action-btn {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
   color: #fff;
+  transition: transform 0.1s, background 0.15s;
+  backdrop-filter: blur(4px);
 }
 
-.hint-keep  { background: rgba(52, 199, 89,  0.85); }
-.hint-trash { background: rgba(255, 59, 48, 0.85); }
-
-/* ── Stamp label (after decision) ────────────────────────── */
-.stamp {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .05em;
-  padding: 2px 6px;
-  border-radius: 4px;
-  color: #fff;
-  pointer-events: none;
+.action-btn:hover {
+  transform: scale(1.05);
 }
 
-.stamp-keep  { background: #34c759; }
-.stamp-trash { background: #ff3b30; }
+.action-btn:active {
+  transform: scale(0.97);
+}
+
+.btn-keep {
+  background: rgba(52, 199, 89, 0.9);
+}
+
+.btn-keep:hover {
+  background: #2db84e;
+}
+
+.btn-trash {
+  background: rgba(255, 59, 48, 0.9);
+}
+
+.btn-trash:hover {
+  background: #e0342a;
+}
+
+.btn-undo {
+  background: rgba(100, 100, 100, 0.85);
+}
+
+.btn-undo:hover {
+  background: rgba(80, 80, 80, 0.95);
+}
+
+.btn-preview {
+  background: rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.btn-preview:hover {
+  background: rgba(255, 255, 255, 0.4);
+}
 
 /* ── Empty state ─────────────────────────────────────────── */
 #empty-msg {
@@ -159,4 +310,127 @@ main {
   color: #888;
   margin-top: 60px;
   font-size: 1rem;
+}
+
+/* ── Lightbox ────────────────────────────────────────────── */
+.lightbox[hidden],
+.modal-overlay[hidden] {
+  display: none !important;
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lightbox-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(8px);
+}
+
+.lightbox-img {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  border-radius: 8px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+  object-fit: contain;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  background: rgba(255, 255, 255, 0.15);
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+  backdrop-filter: blur(4px);
+}
+
+.lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+/* ── Confirm modal ───────────────────────────────────────── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(4px);
+}
+
+.modal {
+  background: #fff;
+  border-radius: 14px;
+  padding: 28px 32px 24px;
+  max-width: 380px;
+  width: 90%;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+  text-align: center;
+}
+
+.modal-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.modal-desc {
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 24px;
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.modal-btn {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.modal-cancel {
+  background: #f0f0f0;
+  color: #333;
+}
+
+.modal-cancel:hover {
+  background: #e4e4e4;
+}
+
+.modal-confirm {
+  background: #ff3b30;
+  color: #fff;
+}
+
+.modal-confirm:hover {
+  background: #e0342a;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,14 +11,59 @@
     <h1>Screenshot Declutterer</h1>
     <div class="header-right">
       <span id="status-msg"></span>
+      <button id="undo-btn" disabled>Undo</button>
       <button id="done-btn" disabled>Done</button>
     </div>
   </header>
 
-  <main>
-    <div id="screenshot-grid"></div>
-    <p id="empty-msg" hidden>No screenshots found on your Desktop.</p>
-  </main>
+  <div class="kanban">
+    <!-- Keep column (left) -->
+    <section class="column column-keep" id="col-keep" data-column="keep">
+      <div class="column-header">
+        <span class="column-title">Keep</span>
+        <span class="column-count" id="count-keep">0</span>
+      </div>
+      <div class="column-cards" id="cards-keep"></div>
+    </section>
+
+    <!-- Unsorted column (center) -->
+    <section class="column column-unsorted" id="col-unsorted" data-column="unsorted">
+      <div class="column-header">
+        <span class="column-title">Unsorted</span>
+        <span class="column-count" id="count-unsorted">0</span>
+      </div>
+      <div class="column-cards" id="cards-unsorted"></div>
+      <p id="empty-msg" hidden>No screenshots found on your Desktop.</p>
+    </section>
+
+    <!-- Trash column (right) -->
+    <section class="column column-trash" id="col-trash" data-column="trash">
+      <div class="column-header">
+        <span class="column-title">Trash</span>
+        <span class="column-count" id="count-trash">0</span>
+      </div>
+      <div class="column-cards" id="cards-trash"></div>
+    </section>
+  </div>
+
+  <!-- Lightbox -->
+  <div id="lightbox" class="lightbox" hidden>
+    <div class="lightbox-backdrop"></div>
+    <img class="lightbox-img" id="lightbox-img" src="" alt="" />
+    <button class="lightbox-close" id="lightbox-close" aria-label="Close">&times;</button>
+  </div>
+
+  <!-- Confirm modal -->
+  <div id="confirm-modal" class="modal-overlay" hidden>
+    <div class="modal">
+      <p class="modal-title" id="modal-title">Move screenshots to Trash?</p>
+      <p class="modal-desc">This uses macOS Trash — you can recover files if needed.</p>
+      <div class="modal-actions">
+        <button class="modal-btn modal-cancel" id="modal-cancel">Cancel</button>
+        <button class="modal-btn modal-confirm" id="modal-confirm">Move to Trash</button>
+      </div>
+    </div>
+  </div>
 
   <script src="/static/app.js"></script>
 </body>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,6 +27,23 @@ def test_index_returns_html(client):
     assert b"Screenshot Declutterer" in r.data
 
 
+def test_index_has_undo_button(client):
+    """Global undo button should be present in the header."""
+    c, _ = client
+    r = c.get("/")
+    assert b'id="undo-btn"' in r.data
+
+
+def test_index_column_order_keep_unsorted_trash(client):
+    """Keep column should appear before Unsorted, Trash should appear last."""
+    c, _ = client
+    html = c.get("/").data.decode()
+    keep_pos = html.index('id="col-keep"')
+    unsorted_pos = html.index('id="col-unsorted"')
+    trash_pos = html.index('id="col-trash"')
+    assert keep_pos < unsorted_pos < trash_pos
+
+
 # ── GET /api/screenshots ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **Swapped column positions**: Layout is now **Keep (left) | Unsorted (center) | Trash (right)** — Trash area is on the right as requested
- **Added global Undo button**: Visible "Undo" button in the header bar (next to Done) that reverses the last sort action. Disabled when nothing to undo. Does NOT undo actual delete operations — undo stack is cleared after trash.
- Arrow labels (`← Keep`, `Trash →`) and keyboard shortcuts (ArrowLeft=keep, ArrowRight=trash) already matched the new layout
- Added 2 new tests (22 total): column order verification and undo button presence

Resolves #15, Resolves #16

## Test plan

- [ ] App loads with Keep on left, Trash on right
- [ ] Dragging a card right sends to Trash, dragging left sends to Keep
- [ ] Keyboard ArrowLeft = keep, ArrowRight = trash (unchanged)
- [ ] Undo button is grayed out initially, becomes active after sorting a card
- [ ] Clicking Undo reverses the last sort action
- [ ] Cmd/Ctrl+Z still works as keyboard undo
- [ ] After clicking Done and confirming, Undo button resets to disabled
- [ ] `uv run pytest` — 22 tests pass