### PR TITLE
feat: reduce Keep/Trash thumbnails by ~38% and add perf improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import time
 import webbrowser
 from pathlib import Path
 
-from flask import Flask, abort, jsonify, render_template, request, send_file
+from flask import Flask, abort, jsonify, make_response, render_template, request, send_file
 from send2trash import send2trash
 
 app = Flask(__name__)
@@ -39,7 +39,9 @@ def api_image(filename):
         abort(400)
     if not image_path.exists():
         abort(404)
-    return send_file(image_path)
+    response = make_response(send_file(image_path))
+    response.headers["Cache-Control"] = "private, max-age=3600"
+    return response
 
 
 @app.route("/api/done", methods=["POST"])

--- a/static/app.js
+++ b/static/app.js
@@ -2,6 +2,7 @@
 // decisions: Map<filename, 'keep' | 'trash'>
 const decisions = new Map();
 const undoStack = []; // { filename, from, to }
+let totalCards = 0;
 
 // ── DOM refs ─────────────────────────────────────────────────────────────────
 const cardsUnsorted = document.getElementById("cards-unsorted");
@@ -39,6 +40,7 @@ fetch("/api/screenshots")
       emptyMsg.hidden = false;
       return;
     }
+    totalCards = filenames.length;
     filenames.forEach(f => cardsUnsorted.appendChild(makeCard(f, "unsorted")));
     updateCounts();
   })
@@ -58,6 +60,7 @@ function makeCard(filename, column) {
   img.src = `/api/image/${encodeURIComponent(filename)}`;
   img.alt = filename;
   img.loading = "lazy";
+  img.decoding = "async";
 
   const actions = document.createElement("div");
   actions.className = "card-actions";
@@ -266,10 +269,13 @@ function performUndo() {
 
 // ── Counts & status ──────────────────────────────────────────────────────────
 function updateCounts() {
-  const nUnsorted = cardsUnsorted.querySelectorAll(".card").length;
-  const nTrash    = cardsTrash.querySelectorAll(".card").length;
-  const nKeep     = cardsKeep.querySelectorAll(".card").length;
-  const total     = nUnsorted + nTrash + nKeep;
+  let nKeep = 0, nTrash = 0;
+  for (const v of decisions.values()) {
+    if (v === "keep") nKeep++;
+    else nTrash++;
+  }
+  const nUnsorted = totalCards - nKeep - nTrash;
+  const total     = totalCards;
 
   countUnsorted.textContent = nUnsorted;
   countTrash.textContent    = nTrash;
@@ -329,7 +335,7 @@ modalConfirm.addEventListener("click", () => {
       toTrash.forEach(filename => {
         if (!failed.has(filename)) {
           const card = cardsTrash.querySelector(`[data-filename="${CSS.escape(filename)}"]`);
-          if (card) card.remove();
+          if (card) { card.remove(); totalCards--; }
           decisions.delete(filename);
         }
       });

--- a/static/style.css
+++ b/static/style.css
@@ -173,6 +173,13 @@ header h1 {
   gap: 8px;
 }
 
+/* ── Compact thumbnails in Keep/Trash columns ─────────────── */
+.column-keep .card img,
+.column-trash .card img {
+  width: 62%;
+  margin: 0 auto;
+}
+
 /* ── Drop zone highlight ─────────────────────────────────── */
 .column.drag-over {
   background: rgba(0, 122, 255, 0.04);

--- a/templates/index.html
+++ b/templates/index.html
@@ -49,7 +49,7 @@
   <!-- Lightbox -->
   <div id="lightbox" class="lightbox" hidden>
     <div class="lightbox-backdrop"></div>
-    <img class="lightbox-img" id="lightbox-img" src="" alt="" />
+    <img class="lightbox-img" id="lightbox-img" src="" alt="" decoding="async" />
     <button class="lightbox-close" id="lightbox-close" aria-label="Close">&times;</button>
   </div>
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -229,6 +229,18 @@ def test_api_image_content_type_png(client):
     assert "image/png" in r.content_type
 
 
+def test_api_image_has_cache_control_header(client):
+    """Image endpoint should include a Cache-Control header for browser caching."""
+    c, desktop = client
+    img = desktop / "Screenshot 2024-05-01 at 12.00.00 PM.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    r = c.get("/api/image/Screenshot 2024-05-01 at 12.00.00 PM.png")
+    assert r.status_code == 200
+    assert "Cache-Control" in r.headers
+    assert "max-age" in r.headers["Cache-Control"]
+
+
 def test_api_screenshots_ignores_non_png_screenshot_files(client):
     """Files like Screenshot*.jpg should not appear in the listing."""
     c, desktop = client


### PR DESCRIPTION
## Summary

- Thumbnails in Keep and Trash columns are now ~38% smaller (62% of card width, centred) — cards in Unsorted are unchanged. Double-click / Preview button still opens full-resolution lightbox.
- `/api/image` now returns `Cache-Control: private, max-age=3600` so the browser reuses cached images on repeated lightbox opens and thumbnail loads.
- `updateCounts()` no longer queries the DOM on every card move — counts are derived from the `decisions` Map via a single iteration, with a `totalCards` counter tracking removals.
- Thumbnail and lightbox `<img>` elements now carry `decoding="async"` to avoid blocking the main thread during image decode.

Resolves #18, Resolves #19

## Test plan

- [x] 23/23 tests pass (added `test_api_image_has_cache_control_header`)
- [x] ruff, ruff-format, pyright, pytest pre-commit hooks all passed
- [ ] Visual: drag a card to Keep or Trash — thumbnail appears noticeably smaller than cards in Unsorted
- [ ] Visual: double-click a small card in Keep/Trash — full-resolution lightbox opens correctly
- [ ] Network: open DevTools → Network tab, open the same image twice in the lightbox — second request should be served from cache (status 304 or `(from disk cache)`)