### PR TITLE
docs: add Makefile and clean up README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: install run dev test lint typecheck check clean
+
+install:            ## Install production dependencies
+	uv sync
+
+run:                ## Start the app (opens browser at localhost:5001)
+	uv run python app.py
+
+dev:                ## Install all dependencies including dev tools
+	uv sync --group dev
+
+test:               ## Run tests
+	uv run pytest
+
+lint:               ## Lint with Ruff
+	uv run ruff check .
+
+typecheck:          ## Type-check with Pyright
+	uv run pyright
+
+check: lint typecheck test   ## Run lint + typecheck + tests
+
+clean:              ## Remove caches and build artifacts
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .ruff_cache -exec rm -rf {} + 2>/dev/null || true
+
+help:               ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Nothing leaves your machine — the entire app runs locally.
 ```bash
 git clone https://github.com/Collaboration95/screenshot-declutterer.git
 cd screenshot-declutterer
-uv sync
-uv run python app.py
+make install
+make run
 ```
 
 Your browser opens automatically at `http://localhost:5001`.
@@ -73,26 +73,14 @@ Your browser opens automatically at `http://localhost:5001`.
 ## Development
 
 ```bash
-# Install dev dependencies
-uv sync --group dev
-
-# Run tests
-uv run pytest
-
-# Lint & type-check
-uv run ruff check .
-uv run pyright
+make dev        # Install dev dependencies
+make test       # Run tests
+make lint       # Lint with Ruff
+make typecheck  # Type-check with Pyright
+make check      # Run all checks (lint + typecheck + tests)
 ```
 
-## Contributing
-
-Contributions are welcome! Please open an issue first to discuss what you'd like to change.
-
-1. Fork the repo
-2. Create your feature branch (`git checkout -b feature/my-feature`)
-3. Commit your changes
-4. Push to the branch (`git push origin feature/my-feature`)
-5. Open a Pull Request
+Run `make` or `make help` to see all available targets.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add a `Makefile` with targets for install, run, dev, test, lint, typecheck, check, clean, and help
- Replace raw `uv` commands in README with `make` targets
- Remove contributing guidelines section

## Test plan
- [ ] `make help` displays all targets
- [ ] `make install` runs `uv sync`
- [ ] `make run` starts the app