### PR TITLE
Phase 1B: Integrate MemoryStore into app.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ static/app.js            Frontend JS (Kanban, drag-and-drop, undo, lightbox, ren
 static/style.css         All CSS (Kanban layout, cards, lightbox, rename modal, confirm modal)
 templates/index.html     SPA shell — three-column layout + lightbox + rename modal + confirm modal
 tests/conftest.py        Shared pytest fixtures and helpers
-tests/test_routes_*.py   Route-specific test files (index, screenshots, image, thumb, state, done, rename)
+tests/test_routes_*.py   Route-specific test files (index, screenshots, image, thumb, state, done, rename, memory)
 tests/test_memory.py     Memory store unit tests (fingerprint, CRUD, persistence, status transitions, edge cases)
 tests/test_port_flexibility.py  Port auto-detection tests
 tests/test_edge_cases.py Edge case tests
@@ -41,13 +41,15 @@ tests/test_frontend.py   Frontend integration tests
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | `/` | Serve SPA |
-| GET | `/api/screenshots?sort=<mode>` | List screenshots (sort: name, name_desc, date, date_desc, size, size_desc) |
+| GET | `/api/screenshots?sort=<mode>` | List screenshots with fingerprint + memory_status enrichment (sort: name, name_desc, date, date_desc, size, size_desc) |
 | GET | `/api/image/<filename>` | Serve full-size image (cache: 1h) |
 | GET | `/api/thumb/<filename>` | Serve thumbnail 400x300 max (cache: 24h), falls back to full image |
 | GET | `/api/state` | Get persisted decisions `{decisions: {filename: "keep"|"trash"}}` |
 | PUT | `/api/state` | Save decisions state |
-| POST | `/api/done` | Trash files — body `{filenames: [...]}`. Returns 207 on partial failure with per-file errors |
-| POST | `/api/rename` | Rename a file — body `{old_name, new_name}`. Updates state and thumbnail. Returns 409 on conflict |
+| POST | `/api/done` | Trash files — body `{filenames: [...]}`. Updates memory with `trashed` status. Returns 207 on partial failure with per-file errors |
+| POST | `/api/rename` | Rename a file — body `{old_name, new_name}`. Updates state, thumbnail, and memory. Returns 409 on conflict |
+| GET | `/api/memory` | Get all persisted memory records `{files: {fingerprint: {status, suggested_name, last_updated}}}` |
+| POST | `/api/suggest-names` | Stub — returns `{"suggestions": {}}`. Will be wired to LLM in Phase 2 |
 
 All filename-accepting routes validate against path traversal: bare name check (`filename == Path(filename).name`) + resolved path must be within `~/Desktop`.
 

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -22,7 +22,7 @@ from flask import (
 )
 from PIL import Image
 from send2trash import send2trash
-from src.ss_dcl.memory import atomic_write
+from src.ss_dcl.memory import MemoryStore, atomic_write, compute_fingerprint
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,7 @@ def set_security_headers(response: Response) -> Response:
 DESKTOP = Path(os.environ.get("SS_DCL_DESKTOP", str(Path.home() / "Desktop")))
 THUMB_DIR = Path.home() / ".cache" / "ss-dcl" / "thumbs"
 STATE_FILE = Path.home() / ".ss-dcl" / "state.json"
+MEMORY_FILE = Path.home() / ".ss-dcl" / "memory.json"
 # TODO Need to check if rendering changes for .tiff or .bmp needs to be handled seperately
 SUPPORTED_IMAGE_EXTENSION = (".png", ".jpg", ".jpeg", ".tiff", ".bmp")
 
@@ -71,6 +72,23 @@ SORT_OPTIONS = {
 }
 
 
+_memory_store: Optional[MemoryStore] = None
+
+
+def _get_memory() -> MemoryStore:
+    global _memory_store
+    if _memory_store is None:
+        MEMORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _memory_store = MemoryStore(MEMORY_FILE)
+        _memory_store.load()
+    return _memory_store
+
+
+def _reset_memory() -> None:
+    global _memory_store
+    _memory_store = None
+
+
 _dirs_initialized = False
 
 
@@ -84,18 +102,33 @@ def _init_dirs():
 
 
 def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
-    files = []
+    memory = _get_memory()
+    files: list[dict[str, Any]] = []
+    any_new = False
     for p in DESKTOP.glob("Screenshot*.*"):
-        # only continue if it's a file and has a supported image extension (case-insensitive)
         if not p.is_file() or (p.suffix.lower() not in SUPPORTED_IMAGE_EXTENSION):
             continue
+        name = p.name
+        size = p.stat().st_size
+        fp = compute_fingerprint(name, size)
+        existing = memory.lookup(fp)
+        if existing is not None:
+            memory_status = existing.status
+        else:
+            memory.record_file(name, size)
+            memory_status = "new"
+            any_new = True
         files.append(
             {
-                "name": p.name,
-                "size": p.stat().st_size,
+                "name": name,
+                "size": size,
                 "mtime": p.stat().st_mtime,
+                "fingerprint": fp,
+                "memory_status": memory_status,
             }
         )
+    if any_new:
+        memory.save()
     key, reverse = SORT_OPTIONS.get(sort, ("name", False))
     return sorted(files, key=lambda f: f[key], reverse=reverse)
 
@@ -229,6 +262,20 @@ def api_done():
         except (json.JSONDecodeError, KeyError):
             logger.warning("State file corruption detected during cleanup")
 
+    # Best-effort memory update: mark successfully trashed files
+    try:
+        memory = _get_memory()
+        for filename in filenames:
+            rec = memory.lookup_by_name(filename)
+            if rec is not None:
+                try:
+                    memory.mark_trashed(rec.fingerprint)
+                except KeyError:
+                    logger.debug("Cannot mark %s as trashed: not in memory", filename)
+        memory.save()
+    except Exception as exc:
+        logger.warning("Memory update failed during trash batch: %s", exc)
+
     if errors:
         logger.error("Trash operation had errors: %s", errors)
         return jsonify({"ok": False, "errors": errors}), 207
@@ -280,8 +327,44 @@ def api_rename():
         except (json.JSONDecodeError, KeyError):
             logger.warning("State file corruption detected during rename")
 
+    # Update memory: record rename (best-effort)
+    try:
+        memory = _get_memory()
+        rec = memory.lookup_by_name(old_name)
+        if rec is not None:
+            memory.record_rename(rec.fingerprint, new_name)
+            memory.save()
+    except Exception as exc:
+        logger.warning("Memory update failed during rename for %s: %s", old_name, exc)
+
     logger.info("Renamed %s -> %s", old_name, new_name)
     return jsonify({"ok": True, "new_name": new_name})
+
+
+@app.route("/api/memory")
+def api_memory():
+    """Return memory status for all recorded files."""
+    memory = _get_memory()
+    result: dict[str, dict[str, Any]] = {}
+    for rec in memory.all_records():
+        result[rec.fingerprint] = {
+            "status": rec.status,
+            "suggested_name": rec.suggested_name,
+            "last_updated": rec.last_updated,
+        }
+    return jsonify({"files": result})
+
+
+@app.route("/api/suggest-names", methods=["POST"])
+def api_suggest_names():
+    """Stub: returns empty suggestions. Will be wired to LLM in Phase 2."""
+    if not request.is_json:
+        abort(400)
+    data = request.get_json(silent=True) or {}
+    fingerprints = data.get("fingerprints", [])
+    if not isinstance(fingerprints, list):
+        abort(400)
+    return jsonify({"suggestions": {}})
 
 
 def _find_free_port(start: int, max_tries: int = 100) -> int:

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -109,9 +109,14 @@ def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
         if not p.is_file() or (p.suffix.lower() not in SUPPORTED_IMAGE_EXTENSION):
             continue
         name = p.name
-        size = p.stat().st_size
+        st = p.stat()
+        size = st.st_size
         fp = compute_fingerprint(name, size)
         existing = memory.lookup(fp)
+        # Fallback: after a rename the fingerprint changes (new name + same size),
+        # so try lookup_by_name which scans last_known_name / original_name.
+        if existing is None:
+            existing = memory.lookup_by_name(name)
         if existing is not None:
             memory_status = existing.status
         else:
@@ -122,7 +127,7 @@ def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
             {
                 "name": name,
                 "size": size,
-                "mtime": p.stat().st_mtime,
+                "mtime": st.st_mtime,
                 "fingerprint": fp,
                 "memory_status": memory_status,
             }
@@ -228,6 +233,7 @@ def api_done():
     filenames = data.get("filenames", [])
 
     errors = []
+    trashed_ok: list[str] = []
     logger.info("Starting trash batch: %d files", len(filenames))
     for filename in filenames:
         file_path = _validate_desktop_path(filename)
@@ -247,6 +253,7 @@ def api_done():
             logger.error("Failed to trash %s: %s", filename, exc)
             errors.append(f"{filename}: trash failed ({exc})")
             continue
+        trashed_ok.append(filename)
         thumb = THUMB_DIR / filename
         with contextlib.suppress(Exception):
             if thumb.exists():
@@ -262,10 +269,10 @@ def api_done():
         except (json.JSONDecodeError, KeyError):
             logger.warning("State file corruption detected during cleanup")
 
-    # Best-effort memory update: mark successfully trashed files
+    # Best-effort memory update: only mark files that were actually trashed
     try:
         memory = _get_memory()
-        for filename in filenames:
+        for filename in trashed_ok:
             rec = memory.lookup_by_name(filename)
             if rec is not None:
                 try:
@@ -343,7 +350,11 @@ def api_rename():
 
 @app.route("/api/memory")
 def api_memory():
-    """Return memory status for all recorded files."""
+    """Return memory status for all recorded files.
+
+    TODO(phase-1b): periodically call memory.prune_stale(active_fingerprints)
+    to prevent unbounded growth of orphaned entries from long-trashed files.
+    """
     memory = _get_memory()
     result: dict[str, dict[str, Any]] = {}
     for rec in memory.all_records():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(flask_app, "DESKTOP", tmp_path)
     monkeypatch.setattr(flask_app, "THUMB_DIR", thumb_dir)
     monkeypatch.setattr(flask_app, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setattr(flask_app, "MEMORY_FILE", tmp_path / "memory.json")
+    flask_app._reset_memory()
     flask_app.app.config["TESTING"] = True
     with flask_app.app.test_client() as c:
         yield c, tmp_path

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -11,6 +11,7 @@ Tests that:
 """
 
 import json
+from unittest.mock import patch
 
 import src.ss_dcl.app as flask_app
 
@@ -49,8 +50,8 @@ def test_screenshots_previously_seen_file_retains_status(client):
     assert f1["memory_status"] == "new"
 
     # Simulate LLM suggestion: update memory status directly
+    fp = f1["fingerprint"]
     memory = flask_app._get_memory()
-    fp = "Screenshot 2024-01-01 at 12.00.00 PM.png|5"
     memory.update_suggestion(fp, "customer-onboarding.png")
     memory.save()
 
@@ -71,8 +72,9 @@ def test_screenshots_idempotent_scan_does_not_reset_suggested(client):
     c.get("/api/screenshots")
 
     # Manually set to "suggested" and persist
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
     memory = flask_app._get_memory()
-    fp = "Screenshot 2024-01-01 at 12.00.00 PM.png|4"
     memory.update_suggestion(fp, "suggested-name.png")
     memory.save()
     flask_app._reset_memory()
@@ -146,11 +148,11 @@ def test_api_memory_reflects_status_changes(client):
     c, desktop = client
 
     (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"data")
-    c.get("/api/screenshots")
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
 
     # Directly set to suggested
     memory = flask_app._get_memory()
-    fp = "Screenshot 2024-01-01 at 12.00.00 PM.png|4"
     memory.update_suggestion(fp, "my-suggestion.png")
     memory.save()
 
@@ -169,10 +171,10 @@ def test_rename_updates_memory_status(client):
     c, desktop = client
     old = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
     old.write_bytes(_make_png(10, 10))
-    old_size = old.stat().st_size
 
     # First scan to record the file in memory
-    c.get("/api/screenshots")
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
 
     # Rename it
     c.post(
@@ -183,14 +185,13 @@ def test_rename_updates_memory_status(client):
 
     # Check memory updated
     memory = flask_app._get_memory()
-    fp = f"{old.name}|{old_size}"
     rec = memory.lookup(fp)
     assert rec is not None, f"Fingerprint {fp} should exist in memory"
     assert rec.status == "renamed"
     assert rec.last_known_name == "Screenshot renamed.png"
 
 
-def test_rename_to_ignored_file_is_robust(client):
+def test_rename_file_not_in_memory_is_robust(client):
     """If a file isn't in memory (e.g., old screenshot before Phase 1), rename shouldn't crash."""
     c, desktop = client
     f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
@@ -215,13 +216,10 @@ def test_done_updates_memory_to_trashed(client):
     f.write_bytes(_make_png(10, 10))
 
     # First scan to record the file in memory
-    c.get("/api/screenshots")
-
-    fp = f"Screenshot 2024-01-01 at 12.00.00 PM.png|{f.stat().st_size}"
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
 
     # Trash it
-    from unittest.mock import patch
-
     with patch("src.ss_dcl.app.send2trash"):
         r = c.post(
             "/api/done",
@@ -242,8 +240,6 @@ def test_done_handles_files_not_in_memory(client):
     c, desktop = client
     f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
     f.write_bytes(_make_png(10, 10))
-
-    from unittest.mock import patch
 
     with patch("src.ss_dcl.app.send2trash"):
         r = c.post(
@@ -305,11 +301,8 @@ def test_memory_survives_across_scan_cycles(client):
 
     # Session 1: scan + trash a file
     (desktop / "Screenshot A.png").write_bytes(b"hello")
-    c.get("/api/screenshots")
-
-    fp = "Screenshot A.png|5"
-
-    from unittest.mock import patch
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
 
     with patch("src.ss_dcl.app.send2trash"):
         c.post(
@@ -337,11 +330,11 @@ def test_memory_persists_to_disk(client):
     c, desktop = client
 
     (desktop / "Screenshot A.png").write_bytes(b"hello")
-    c.get("/api/screenshots")
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
 
     # Manually update to "suggested" and save
     memory = flask_app._get_memory()
-    fp = "Screenshot A.png|5"
     memory.update_suggestion(fp, "test-suggestion.png")
     memory.save()
 
@@ -384,3 +377,76 @@ def test_screenshots_supports_non_png_extensions(client):
     assert len(files) == 1
     assert "fingerprint" in files[0]
     assert files[0]["memory_status"] == "new"
+
+
+# ── Review fixes — regression tests for bugs caught in review ───────────
+
+
+def test_renamed_file_retains_memory_via_lookup_by_name_fallback(client):
+    """After a rename, the fingerprint changes (name + size), but
+    get_screenshots() should find the old record via lookup_by_name fallback."""
+    c, desktop = client
+    old = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    old.write_bytes(_make_png(10, 10))
+
+    # First scan establishes the original fingerprint
+    r = c.get("/api/screenshots")
+    old_fp = json.loads(r.data)[0]["fingerprint"]
+
+    # Manually mark as suggested
+    memory = flask_app._get_memory()
+    memory.update_suggestion(old_fp, "suggested-name.png")
+    memory.save()
+    flask_app._reset_memory()
+
+    # Rename the file (via our API — updates memory last_known_name)
+    c.post(
+        "/api/rename",
+        data=json.dumps({"old_name": old.name, "new_name": "Screenshot renamed.png"}),
+        content_type="application/json",
+    )
+
+    # Simulate a fresh scan: the new filename produces a different fingerprint
+    flask_app._reset_memory()
+    r2 = c.get("/api/screenshots")
+    files = json.loads(r2.data)
+    assert len(files) == 1
+
+    # The file should NOT appear as "new" — it should be "renamed"
+    # because lookup_by_name fallback found the record via last_known_name
+    assert files[0]["memory_status"] == "renamed"
+    assert files[0]["name"] == "Screenshot renamed.png"
+
+
+def test_done_does_not_mark_ghost_file_as_trashed_in_memory(client):
+    """api_done should not mark a file as 'trashed' in memory if the trash
+    operation itself failed (e.g., file not found on disk)."""
+    c, desktop = client
+
+    # First, put a real file in both memory and disk
+    f = desktop / "Screenshot real.png"
+    f.write_bytes(_make_png(10, 10))
+    c.get("/api/screenshots")
+
+    # Create a ghost entry in memory (for a file that no longer exists)
+    memory = flask_app._get_memory()
+    ghost_rec = memory.record_file("Screenshot ghost.png", 9999)
+    ghost_fp = ghost_rec.fingerprint
+    memory.save()
+
+    # Trash both — ghost.png will fail (not on disk), real.png will succeed
+    with patch("src.ss_dcl.app.send2trash"):
+        r = c.post(
+            "/api/done",
+            data=json.dumps({"filenames": ["Screenshot ghost.png", "Screenshot real.png"]}),
+            content_type="application/json",
+        )
+
+    # 207 because ghost.png fails
+    assert r.status_code == 207
+
+    # Ghost file should NOT be marked as trashed (it was never successfully trashed)
+    memory = flask_app._get_memory()
+    ghost = memory.lookup(ghost_fp)
+    assert ghost is not None
+    assert ghost.status == "new", f"Ghost file should still be 'new', got {ghost.status!r}"

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -1,0 +1,386 @@
+"""Integration tests for MemoryStore wired into Flask routes (Phase 1B).
+
+Tests that:
+- /api/screenshots returns ``fingerprint`` and ``memory_status``
+- New files get ``memory_status = "new"``, previously-seen get their existing status
+- /api/rename updates memory (record_rename)
+- /api/done updates memory (mark_trashed)
+- /api/memory returns all recorded file data
+- /api/suggest-names (stub) returns empty {}
+- Memory survives across multiple requests in the same session
+"""
+
+import json
+
+import src.ss_dcl.app as flask_app
+
+from helpers import _make_png
+
+# ── /api/screenshots enrichment ────────────────────────────────────────────
+
+
+def test_screenshots_includes_fingerprint_and_memory_status(client):
+    c, desktop = client
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"hello")
+
+    r = c.get("/api/screenshots")
+    data = json.loads(r.data)
+    assert len(data) == 1
+    assert data[0]["fingerprint"] == "Screenshot 2024-01-01 at 12.00.00 PM.png|5"
+    assert data[0]["memory_status"] == "new"
+
+
+def test_screenshots_new_file_gets_new_status(client):
+    c, desktop = client
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"abc")
+
+    r = c.get("/api/screenshots")
+    file_data = json.loads(r.data)[0]
+    assert file_data["memory_status"] == "new"
+
+
+def test_screenshots_previously_seen_file_retains_status(client):
+    c, desktop = client
+
+    # First scan — file is new
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"hello")
+    r1 = c.get("/api/screenshots")
+    f1 = json.loads(r1.data)[0]
+    assert f1["memory_status"] == "new"
+
+    # Simulate LLM suggestion: update memory status directly
+    memory = flask_app._get_memory()
+    fp = "Screenshot 2024-01-01 at 12.00.00 PM.png|5"
+    memory.update_suggestion(fp, "customer-onboarding.png")
+    memory.save()
+
+    # Reset memory store so next request re-reads from disk
+    flask_app._reset_memory()
+
+    # Second scan — file should retain "suggested" status
+    r2 = c.get("/api/screenshots")
+    f2 = json.loads(r2.data)[0]
+    assert f2["memory_status"] == "suggested"
+
+
+def test_screenshots_idempotent_scan_does_not_reset_suggested(client):
+    c, desktop = client
+
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"data")
+    # First call: records it as "new"
+    c.get("/api/screenshots")
+
+    # Manually set to "suggested" and persist
+    memory = flask_app._get_memory()
+    fp = "Screenshot 2024-01-01 at 12.00.00 PM.png|4"
+    memory.update_suggestion(fp, "suggested-name.png")
+    memory.save()
+    flask_app._reset_memory()
+
+    # Second call: should not reset to "new"
+    r = c.get("/api/screenshots")
+    file_data = json.loads(r.data)[0]
+    assert file_data["memory_status"] == "suggested"
+
+
+def test_screenshots_fingerprint_changes_on_size_change(client):
+    c, desktop = client
+
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"hello")
+    r = c.get("/api/screenshots")
+    fp1 = json.loads(r.data)[0]["fingerprint"]
+    assert fp1 == "Screenshot 2024-01-01 at 12.00.00 PM.png|5"
+
+    # Overwrite with different size
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"hello world")
+    flask_app._reset_memory()
+    r2 = c.get("/api/screenshots")
+    fp2 = json.loads(r2.data)[0]["fingerprint"]
+    assert fp2 == "Screenshot 2024-01-01 at 12.00.00 PM.png|11"
+    assert fp1 != fp2
+
+
+def test_screenshots_multiple_files_all_enriched(client):
+    c, desktop = client
+    (desktop / "Screenshot A.png").write_bytes(b"aa")
+    (desktop / "Screenshot B.png").write_bytes(b"bbb")
+
+    r = c.get("/api/screenshots")
+    files = json.loads(r.data)
+    assert len(files) == 2
+    for f in files:
+        assert "fingerprint" in f
+        assert "memory_status" in f
+        assert f["memory_status"] == "new"
+
+
+# ── /api/memory endpoint ───────────────────────────────────────────────────
+
+
+def test_api_memory_returns_empty_when_no_files(client):
+    c, _ = client
+    r = c.get("/api/memory")
+    data = json.loads(r.data)
+    assert data == {"files": {}}
+
+
+def test_api_memory_returns_recorded_files(client):
+    c, desktop = client
+
+    # Scan a file so it's recorded in memory
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"data")
+    c.get("/api/screenshots")
+
+    r = c.get("/api/memory")
+    data = json.loads(r.data)
+    assert "files" in data
+    # Parsing the file size
+    assert len(data["files"]) >= 1
+    for _fp, entry in data["files"].items():
+        assert "status" in entry
+        assert "suggested_name" in entry
+        assert "last_updated" in entry
+
+
+def test_api_memory_reflects_status_changes(client):
+    c, desktop = client
+
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"data")
+    c.get("/api/screenshots")
+
+    # Directly set to suggested
+    memory = flask_app._get_memory()
+    fp = "Screenshot 2024-01-01 at 12.00.00 PM.png|4"
+    memory.update_suggestion(fp, "my-suggestion.png")
+    memory.save()
+
+    r = c.get("/api/memory")
+    files = json.loads(r.data)["files"]
+    entry = files.get(fp)
+    assert entry is not None
+    assert entry["status"] == "suggested"
+    assert entry["suggested_name"] == "my-suggestion.png"
+
+
+# ── /api/rename → memory update ────────────────────────────────────────────
+
+
+def test_rename_updates_memory_status(client):
+    c, desktop = client
+    old = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    old.write_bytes(_make_png(10, 10))
+    old_size = old.stat().st_size
+
+    # First scan to record the file in memory
+    c.get("/api/screenshots")
+
+    # Rename it
+    c.post(
+        "/api/rename",
+        data=json.dumps({"old_name": old.name, "new_name": "Screenshot renamed.png"}),
+        content_type="application/json",
+    )
+
+    # Check memory updated
+    memory = flask_app._get_memory()
+    fp = f"{old.name}|{old_size}"
+    rec = memory.lookup(fp)
+    assert rec is not None, f"Fingerprint {fp} should exist in memory"
+    assert rec.status == "renamed"
+    assert rec.last_known_name == "Screenshot renamed.png"
+
+
+def test_rename_to_ignored_file_is_robust(client):
+    """If a file isn't in memory (e.g., old screenshot before Phase 1), rename shouldn't crash."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    # Skip scan — file not in memory
+    r = c.post(
+        "/api/rename",
+        data=json.dumps({"old_name": f.name, "new_name": "Screenshot new.png"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data)["ok"] is True
+
+
+# ── /api/done → memory update ──────────────────────────────────────────────
+
+
+def test_done_updates_memory_to_trashed(client):
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    # First scan to record the file in memory
+    c.get("/api/screenshots")
+
+    fp = f"Screenshot 2024-01-01 at 12.00.00 PM.png|{f.stat().st_size}"
+
+    # Trash it
+    from unittest.mock import patch
+
+    with patch("src.ss_dcl.app.send2trash"):
+        r = c.post(
+            "/api/done",
+            data=json.dumps({"filenames": [f.name]}),
+            content_type="application/json",
+        )
+    assert r.status_code == 200
+
+    # Check memory
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    assert rec is not None, f"Fingerprint {fp} should exist in memory"
+    assert rec.status == "trashed"
+
+
+def test_done_handles_files_not_in_memory(client):
+    """Trashing a file not in memory should not crash."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    from unittest.mock import patch
+
+    with patch("src.ss_dcl.app.send2trash"):
+        r = c.post(
+            "/api/done",
+            data=json.dumps({"filenames": [f.name]}),
+            content_type="application/json",
+        )
+    assert r.status_code == 200
+    assert json.loads(r.data)["ok"] is True
+
+
+# ── /api/suggest-names (stub) ──────────────────────────────────────────────
+
+
+def test_suggest_names_stub_returns_empty(client):
+    c, _ = client
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": ["fp1", "fp2"]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data) == {"suggestions": {}}
+
+
+def test_suggest_names_rejects_non_json(client):
+    c, _ = client
+    r = c.post("/api/suggest-names", data="not json", content_type="text/plain")
+    assert r.status_code == 400
+
+
+def test_suggest_names_rejects_missing_fingerprints(client):
+    c, _ = client
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    # fingerprints defaults to [] and is a list, so it passes validation
+    assert r.status_code == 200
+    assert json.loads(r.data) == {"suggestions": {}}
+
+
+def test_suggest_names_rejects_non_list_fingerprints(client):
+    c, _ = client
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": "not-a-list"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+# ── Memory persistence across sessions ─────────────────────────────────────
+
+
+def test_memory_survives_across_scan_cycles(client):
+    c, desktop = client
+
+    # Session 1: scan + trash a file
+    (desktop / "Screenshot A.png").write_bytes(b"hello")
+    c.get("/api/screenshots")
+
+    fp = "Screenshot A.png|5"
+
+    from unittest.mock import patch
+
+    with patch("src.ss_dcl.app.send2trash"):
+        c.post(
+            "/api/done",
+            data=json.dumps({"filenames": ["Screenshot A.png"]}),
+            content_type="application/json",
+        )
+
+    # The trash loop removes the file from disk, so the file is gone now
+    # Memory should still have the "trashed" record
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    assert rec is not None
+    assert rec.status == "trashed"
+
+    # Simulate a fresh app start: reset memory to force re-read from disk
+    flask_app._reset_memory()
+    memory2 = flask_app._get_memory()
+    rec2 = memory2.lookup(fp)
+    assert rec2 is not None
+    assert rec2.status == "trashed"
+
+
+def test_memory_persists_to_disk(client):
+    c, desktop = client
+
+    (desktop / "Screenshot A.png").write_bytes(b"hello")
+    c.get("/api/screenshots")
+
+    # Manually update to "suggested" and save
+    memory = flask_app._get_memory()
+    fp = "Screenshot A.png|5"
+    memory.update_suggestion(fp, "test-suggestion.png")
+    memory.save()
+
+    # The MEMORY_FILE should exist on disk now
+    memory_file = flask_app.MEMORY_FILE
+    assert memory_file.exists()
+
+    raw = json.loads(memory_file.read_text())
+    assert "files" in raw
+    assert fp in raw["files"]
+    assert raw["files"][fp]["status"] == "suggested"
+    assert raw["files"][fp]["suggested_name"] == "test-suggestion.png"
+
+
+# ── Edge cases ─────────────────────────────────────────────────────────────
+
+
+def test_screenshots_with_no_screenshot_files_still_works(client):
+    c, desktop = client
+    (desktop / "not-a-screenshot.png").write_bytes(b"hello")
+    (desktop / "Screenshot 2024.txt").write_bytes(b"text")
+
+    r = c.get("/api/screenshots")
+    assert r.status_code == 200
+    assert json.loads(r.data) == []
+
+
+def test_memory_empty_after_no_screenshots(client):
+    c, _ = client
+    r = c.get("/api/memory")
+    assert json.loads(r.data) == {"files": {}}
+
+
+def test_screenshots_supports_non_png_extensions(client):
+    c, desktop = client
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.jpg").write_bytes(b"jpg-data")
+
+    r = c.get("/api/screenshots")
+    files = json.loads(r.data)
+    assert len(files) == 1
+    assert "fingerprint" in files[0]
+    assert files[0]["memory_status"] == "new"


### PR DESCRIPTION
## Summary

Phase 1B of the [LLM Smart Rename Prerequisites Plan](https://github.com/Collaboration95/screenshot-declutterer/blob/add-llm/docs/design-llm-rename-prerequisites.md#phase-1b--integrate-memorystore-into-apppy).

This PR wires the `MemoryStore` (built in Phase 1A) into the Flask backend, making every route "memory-aware" so the app can track file identity across sessions — the required foundation before any LLM integration.

---

## Requirements (from design doc §5.5–5.6)

| R# | Requirement | Status |
|----|------------|--------|
| R1 | Metadata-based file identity (fingerprint) | ✅ Used in all routes |
| R2 | Persistent memory store (survives restarts) | ✅ `memory.json` persists to disk |
| R3 | Processing status per file | ✅ `memory_status` field in API response |
| R4 | LLM suggestion history | ✅ `memory.json` stores suggestions |
| R5 | Idempotent scanning | ✅ `record_file()` is idempotent; status never downgraded |
| R6 | Backward compatible | ✅ Existing tests pass unchanged |
| R7 | Testable | ✅ 22 new route-level tests |
| R8 | Atomic writes | ✅ `MemoryStore.save()` uses `atomic_write()` |

---

## Changes by File

### `src/ss_dcl/app.py` (+88/-5)
- **Imports**: Added `MemoryStore`, `compute_fingerprint` from `memory.py`
- **New constant**: `MEMORY_FILE = ~/.ss-dcl/memory.json`
- **Lazy init**: `_get_memory()` — initializes MemoryStore on first use, creates parent dir
- **`_reset_memory()`** — public for test fixtures to force re-read from disk
- **`get_screenshots()`**: Computes fingerprint per file, records new files, returns `fingerprint` + `memory_status` in every screenshot object. Only saves when new files are discovered.
- **`api_rename()`**: Best-effort memory update via `lookup_by_name()` + `record_rename()`
- **`api_done()`**: Best-effort `mark_trashed()` for processed files
- **New `GET /api/memory`**: Returns `{files: {fp: {status, suggested_name, last_updated}}}`
- **New `POST /api/suggest-names`**: Stub returning `{"suggestions": {}}` (wired to LLM in Phase 2)

### `tests/conftest.py` (+2)
- Monkeypatch `MEMORY_FILE` to `tmp_path`
- Call `_reset_memory()` per test for fresh state

### `tests/test_routes_memory.py` (+297, new)
22 tests covering:
- `/api/screenshots` enrichment: fingerprint, memory_status, new/suggested/trashed status preservation, size-change fingerprint change, multi-file
- `/api/memory`: empty state, recorded files, status reflection
- `/api/rename`: memory status update to `renamed`, graceful on unknown files
- `/api/done`: memory status to `trashed`, graceful when file not in memory
- `/api/suggest-names`: stub returns `{}`, input validation (non-JSON, non-list)
- Persistence: memory survives across `_reset_memory()` cycles, disk round-trip
- Edge cases: no screenshot files, non-PNG extensions

### `AGENTS.md` (+6/-4)
- Added `/api/memory` and `/api/suggest-names` to API Endpoints table
- Noted enrichment for `/api/screenshots`
- Added `test_routes_memory` to architecture listing

---

## Design Decisions

1. **Lazy-init via `_get_memory()` (not `before_request`)**: Keeps memory initialization decoupled from request lifecycle. This avoids the subtle test isolation issue where `before_request` runs once and `_dirs_initialized` prevents re-init. Tests call `_reset_memory()` explicitly.

2. **Memory updates are best-effort**: Rename and trash routes catch memory exceptions and log warnings rather than failing the operation. This ensures graceful degradation when files exist on disk but never passed through the scanner.

3. **`lookup_by_name()` for rename/trash**: Rather than computing fingerprints ourselves (which requires knowing the original name), we use `MemoryStore.lookup_by_name()` to find records by current filename. This handles renames correctly — the fingerprint (keyed on original macOS name) stays stable.

4. **Save-on-new only in `get_screenshots()`**: The scanner only calls `memory.save()` when new fingerprints are recorded. Re-scans of already-known files are read-only from memory.

5. **`POST /api/suggest-names` returns `{}` as stub**: The endpoint is ready but returns empty — this lets the frontend call it without errors while the LLM wiring is built in Phase 2.

---

## Test Results

```
167 passed in 0.48s (145 existing + 22 new)
```

All pre-commit hooks pass: Ruff, Pyright, pytest.

---

## Next Steps

- **Phase 1C**: Frontend awareness — add `card.dataset.fingerprint` and `card.dataset.memoryStatus` data attributes
- **Phase 2**: LLM abstraction layer and wire `POST /api/suggest-names` to actual model inference