### PR TITLE
Phase 3: LLM rename suggestion UI + backend integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,11 @@ tests/test_frontend.py   Frontend integration tests
 | POST | `/api/done` | Trash files — body `{filenames: [...]}`. Updates memory with `trashed` status. Returns 207 on partial failure with per-file errors |
 | POST | `/api/rename` | Rename a file — body `{old_name, new_name}`. Updates state, thumbnail, and memory. Returns 409 on conflict |
 | GET | `/api/memory` | Get all persisted memory records `{files: {fingerprint: {status, suggested_name, last_updated}}}` |
-| POST | `/api/suggest-names` | Stub — returns `{"suggestions": {}}`. Will be wired to LLM in Phase 2 |
+| POST | `/api/suggest-names` | Generate AI filename suggestions via Ollama — body `{fingerprints: [...]}`. Uses `gemma4:e2b` by default |
+| POST | `/api/accept-suggestion` | Accept suggestion & rename file — body `{fingerprint}`. Handles name conflicts (appends `-2`) |
+| POST | `/api/reject-suggestion` | Dismiss suggestion — body `{fingerprint}`. Marks memory status as `"ignored"` |
+| GET | `/api/settings` | Get LLM config `{llm_provider, llm_model, auto_suggest}` |
+| PUT | `/api/settings` | Save LLM config — body `{llm_provider?, llm_model?, auto_suggest?}` |
 
 All filename-accepting routes validate against path traversal: bare name check (`filename == Path(filename).name`) + resolved path must be within `~/Desktop`.
 
@@ -76,6 +80,7 @@ All in `static/app.js`:
 | THUMB_DIR | `~/.cache/ss-dcl/thumbs/` |
 | STATE_FILE | `~/.ss-dcl/state.json` |
 | MEMORY_FILE | `~/.ss-dcl/memory.json` |
+| SETTINGS_FILE | `~/.ss-dcl/settings.json` |
 | THUMB_SIZE | `(400, 300)` |
 
 ## Dependencies
@@ -89,7 +94,7 @@ All in `static/app.js`:
 - Fixture: `client(tmp_path, monkeypatch)` — temp dir as fake Desktop, patches `DESKTOP`, `THUMB_DIR`, `STATE_FILE`
 - `send2trash` always mocked to avoid actually trashing files
 - Helper `_make_png()` creates valid minimal PNGs in-memory
-- ~76 tests across focused test files covering all routes, sorting, path traversal, state round-trip, partial failures, rename, port flexibility, edge cases
+- ~210 tests across focused test files covering all routes, sorting, path traversal, state round-trip, partial failures, rename, port flexibility, edge cases, LLM suggest/accept/reject flows
 
 ## Tooling Config
 

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -426,7 +426,11 @@ def _call_ollama_suggest(image_path: Path, model: str, extension: str = ".png") 
     # Sanitize: lowercase, replace spaces with hyphens, strip punctuation
     sanitized = raw.lower().replace(" ", "-")
     sanitized = "".join(c for c in sanitized if c.isalnum() or c in "-_")
-    sanitized = sanitized.strip("-_")[:120]
+    # Collapse repeated hyphens (from multi-space / punctuation gaps)
+    while "--" in sanitized:
+        sanitized = sanitized.replace("--", "-")
+    # Truncate then strip so trailing hyphen after slice is removed
+    sanitized = sanitized[:120].strip("-_").strip()
     if not sanitized:
         return None
     return sanitized + extension

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -512,11 +512,19 @@ def api_accept_suggestion():
 
     old_name = rec.last_known_name or rec.original_name
     new_name = rec.suggested_name
-    old_path = DESKTOP / old_name
-    new_path = DESKTOP / new_name
 
-    if not old_path.exists():
+    # Defensive: guard against empty/corrupt names from memory.json
+    if not old_name or not new_name:
+        return jsonify({"ok": False, "error": "invalid filename in memory record"}), 400
+
+    # Validate old_name via the same path-traversal guard used by /api/rename
+    old_path = _validate_desktop_path(old_name)
+    if old_path is None:
+        return jsonify({"ok": False, "error": "invalid old_name"}), 400
+    if not old_path.is_file():
         return jsonify({"ok": False, "error": "source file not found on disk"}), 404
+
+    new_path = DESKTOP / new_name
     if new_path.exists():
         # Append a counter to avoid overwriting
         stem = Path(new_name).stem

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -79,20 +79,23 @@ SORT_OPTIONS = {
 
 
 _memory_store: Optional[MemoryStore] = None
+_memory_lock = threading.Lock()
 
 
 def _get_memory() -> MemoryStore:
     global _memory_store
-    if _memory_store is None:
-        MEMORY_FILE.parent.mkdir(parents=True, exist_ok=True)
-        _memory_store = MemoryStore(MEMORY_FILE)
-        _memory_store.load()
+    with _memory_lock:
+        if _memory_store is None:
+            MEMORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+            _memory_store = MemoryStore(MEMORY_FILE)
+            _memory_store.load()
     return _memory_store
 
 
 def _reset_memory() -> None:
     global _memory_store
-    _memory_store = None
+    with _memory_lock:
+        _memory_store = None
 
 
 _dirs_initialized = False
@@ -618,8 +621,23 @@ def api_save_settings():
         abort(400)
 
     current = _load_settings()
+    type_checks = {
+        "llm_provider": str,
+        "llm_model": str,
+        "auto_suggest": bool,
+    }
     for key in ("llm_provider", "llm_model", "auto_suggest"):
         if key in data:
+            if not isinstance(data[key], type_checks[key]):
+                return (
+                    jsonify(
+                        {
+                            "ok": False,
+                            "error": f"{key!r} must be {type_checks[key].__name__}",
+                        }
+                    ),
+                    400,
+                )
             current[key] = data[key]
     _save_settings(current)
     return jsonify({"ok": True})

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -374,11 +374,15 @@ def api_memory():
     return jsonify({"files": result})
 
 
-def _call_ollama_suggest(image_path: Path, model: str) -> Optional[str]:
+def _call_ollama_suggest(image_path: Path, model: str, extension: str = ".png") -> Optional[str]:
     """Call Ollama API with an image and return a suggested filename.
 
     Extracted as a module-level function so tests can monkeypatch it
     without needing Ollama running.
+
+    *extension* is appended to the sanitized name and should include
+    the leading dot (e.g. ``".jpg"``).  Defaults to ``".png"`` for
+    backward compatibility.
     """
     with open(image_path, "rb") as fh:
         image_b64 = base64.b64encode(fh.read()).decode("ascii")
@@ -425,7 +429,7 @@ def _call_ollama_suggest(image_path: Path, model: str) -> Optional[str]:
     sanitized = sanitized.strip("-_")[:120]
     if not sanitized:
         return None
-    return sanitized + ".png"
+    return sanitized + extension
 
 
 def _load_settings() -> dict[str, Any]:
@@ -478,7 +482,7 @@ def api_suggest_names():
         if file_path is None:
             continue
 
-        suggested = _call_ollama_suggest(file_path, model)
+        suggested = _call_ollama_suggest(file_path, model, rec.extension)
         if suggested:
             memory.update_suggestion(fp, suggested)
             suggestions[fp] = suggested

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -1,3 +1,4 @@
+import base64
 import contextlib
 import json
 import logging
@@ -5,6 +6,8 @@ import os
 import socket
 import threading
 import time
+import urllib.error
+import urllib.request
 import webbrowser
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -48,6 +51,9 @@ DESKTOP = Path(os.environ.get("SS_DCL_DESKTOP", str(Path.home() / "Desktop")))
 THUMB_DIR = Path.home() / ".cache" / "ss-dcl" / "thumbs"
 STATE_FILE = Path.home() / ".ss-dcl" / "state.json"
 MEMORY_FILE = Path.home() / ".ss-dcl" / "memory.json"
+SETTINGS_FILE = Path.home() / ".ss-dcl" / "settings.json"
+DEFAULT_LLM_MODEL = "gemma4:e2b"
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
 # TODO Need to check if rendering changes for .tiff or .bmp needs to be handled seperately
 SUPPORTED_IMAGE_EXTENSION = (".png", ".jpg", ".jpeg", ".tiff", ".bmp")
 
@@ -123,6 +129,7 @@ def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
             memory.record_file(name, size)
             memory_status = "new"
             any_new = True
+        suggested_name = existing.suggested_name if existing else None
         files.append(
             {
                 "name": name,
@@ -130,6 +137,7 @@ def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
                 "mtime": st.st_mtime,
                 "fingerprint": fp,
                 "memory_status": memory_status,
+                "suggested_name": suggested_name,
             }
         )
     if any_new:
@@ -366,16 +374,235 @@ def api_memory():
     return jsonify({"files": result})
 
 
+def _call_ollama_suggest(image_path: Path, model: str) -> Optional[str]:
+    """Call Ollama API with an image and return a suggested filename.
+
+    Extracted as a module-level function so tests can monkeypatch it
+    without needing Ollama running.
+    """
+    with open(image_path, "rb") as fh:
+        image_b64 = base64.b64encode(fh.read()).decode("ascii")
+
+    prompt = (
+        "Describe this screenshot in 3-5 words as a filename. "
+        "Return only the filename, no explanation, no quotes."
+    )
+
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": prompt,
+                    "images": [image_b64],
+                }
+            ],
+            "stream": False,
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        f"{OLLAMA_BASE_URL}/api/chat",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read())
+            raw = result.get("message", {}).get("content", "").strip()
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("Ollama suggest failed for %s: %s", image_path.name, exc)
+        return None
+
+    if not raw:
+        return None
+
+    # Sanitize: lowercase, replace spaces with hyphens, strip punctuation
+    sanitized = raw.lower().replace(" ", "-")
+    sanitized = "".join(c for c in sanitized if c.isalnum() or c in "-_")
+    sanitized = sanitized.strip("-_")[:120]
+    if not sanitized:
+        return None
+    return sanitized + ".png"
+
+
+def _load_settings() -> dict[str, Any]:
+    if SETTINGS_FILE.exists():
+        try:
+            return json.loads(SETTINGS_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def _save_settings(settings: dict[str, Any]) -> None:
+    SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(SETTINGS_FILE, json.dumps(settings, indent=2))
+
+
 @app.route("/api/suggest-names", methods=["POST"])
 def api_suggest_names():
-    """Stub: returns empty suggestions. Will be wired to LLM in Phase 2."""
+    """Generate AI filename suggestions for unprocessed screenshots."""
     if not request.is_json:
         abort(400)
     data = request.get_json(silent=True) or {}
     fingerprints = data.get("fingerprints", [])
     if not isinstance(fingerprints, list):
         abort(400)
-    return jsonify({"suggestions": {}})
+
+    settings = _load_settings()
+    model = settings.get("llm_model", DEFAULT_LLM_MODEL)
+
+    memory = _get_memory()
+    suggestions: dict[str, str] = {}
+
+    for fp in fingerprints:
+        rec = memory.lookup(fp)
+        if rec is None:
+            continue
+        if rec.status != "new":
+            continue
+
+        # Locate file on disk via last_known_name or original_name
+        file_path: Optional[Path] = None
+        for candidate_name in (rec.last_known_name, rec.original_name):
+            if not candidate_name:
+                continue
+            p = DESKTOP / candidate_name
+            if p.exists() and p.is_file():
+                file_path = p
+                break
+
+        if file_path is None:
+            continue
+
+        suggested = _call_ollama_suggest(file_path, model)
+        if suggested:
+            memory.update_suggestion(fp, suggested)
+            suggestions[fp] = suggested
+
+    if suggestions:
+        memory.save()
+
+    return jsonify({"suggestions": suggestions})
+
+
+@app.route("/api/accept-suggestion", methods=["POST"])
+def api_accept_suggestion():
+    """Accept an AI suggested name: rename the file on disk."""
+    if not request.is_json:
+        abort(400)
+    data = request.get_json(silent=True) or {}
+    fingerprint = data.get("fingerprint", "")
+    if not fingerprint or not isinstance(fingerprint, str):
+        return jsonify({"ok": False, "error": "fingerprint is required"}), 400
+
+    memory = _get_memory()
+    rec = memory.lookup(fingerprint)
+    if rec is None:
+        return jsonify({"ok": False, "error": "fingerprint not found in memory"}), 404
+    if not rec.suggested_name:
+        return jsonify({"ok": False, "error": "no suggestion to accept"}), 400
+
+    old_name = rec.last_known_name or rec.original_name
+    new_name = rec.suggested_name
+    old_path = DESKTOP / old_name
+    new_path = DESKTOP / new_name
+
+    if not old_path.exists():
+        return jsonify({"ok": False, "error": "source file not found on disk"}), 404
+    if new_path.exists():
+        # Append a counter to avoid overwriting
+        stem = Path(new_name).stem
+        suffix = Path(new_name).suffix
+        counter = 2
+        while (DESKTOP / f"{stem}-{counter}{suffix}").exists():
+            counter += 1
+        new_name = f"{stem}-{counter}{suffix}"
+        new_path = DESKTOP / new_name
+
+    try:
+        old_path.rename(new_path)
+    except OSError as exc:
+        logger.error("Failed to rename %s to %s: %s", old_name, new_name, exc)
+        return jsonify({"ok": False, "error": str(exc)}), 500
+
+    # Move thumbnail
+    old_thumb = THUMB_DIR / old_name
+    new_thumb = THUMB_DIR / new_name
+    with contextlib.suppress(Exception):
+        if old_thumb.exists():
+            old_thumb.rename(new_thumb)
+
+    # Update state.json
+    if STATE_FILE.exists():
+        try:
+            state = json.loads(STATE_FILE.read_text())
+            decisions = state.get("decisions", {})
+            if old_name in decisions:
+                decisions[new_name] = decisions.pop(old_name)
+                atomic_write(STATE_FILE, json.dumps(state))
+        except (json.JSONDecodeError, KeyError):
+            logger.warning("State file corruption during accept-suggestion")
+
+    # Update memory
+    memory.accept_suggestion(fingerprint, new_name)
+    memory.save()
+
+    logger.info("Accepted suggestion: %s → %s", old_name, new_name)
+    return jsonify({"ok": True, "old_name": old_name, "new_name": new_name})
+
+
+@app.route("/api/reject-suggestion", methods=["POST"])
+def api_reject_suggestion():
+    """Reject/dismiss an AI suggested name."""
+    if not request.is_json:
+        abort(400)
+    data = request.get_json(silent=True) or {}
+    fingerprint = data.get("fingerprint", "")
+    if not fingerprint or not isinstance(fingerprint, str):
+        return jsonify({"ok": False, "error": "fingerprint is required"}), 400
+
+    memory = _get_memory()
+    rec = memory.lookup(fingerprint)
+    if rec is None:
+        return jsonify({"ok": False, "error": "fingerprint not found in memory"}), 404
+
+    memory.reject_suggestion(fingerprint)
+    memory.save()
+    return jsonify({"ok": True})
+
+
+@app.route("/api/settings", methods=["GET"])
+def api_get_settings():
+    """Return current LLM/settings configuration."""
+    s = _load_settings()
+    return jsonify(
+        {
+            "llm_provider": s.get("llm_provider", "ollama"),
+            "llm_model": s.get("llm_model", DEFAULT_LLM_MODEL),
+            "auto_suggest": s.get("auto_suggest", False),
+        }
+    )
+
+
+@app.route("/api/settings", methods=["PUT"])
+def api_save_settings():
+    """Save LLM/settings configuration."""
+    if not request.is_json:
+        abort(400)
+    data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        abort(400)
+
+    current = _load_settings()
+    for key in ("llm_provider", "llm_model", "auto_suggest"):
+        if key in data:
+            current[key] = data[key]
+    _save_settings(current)
+    return jsonify({"ok": True})
 
 
 def _find_free_port(start: int, max_tries: int = 100) -> int:

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -457,6 +457,10 @@ def api_suggest_names():
         abort(400)
 
     settings = _load_settings()
+    provider = settings.get("llm_provider", "ollama")
+    if provider != "ollama":
+        msg = f"Provider {provider!r} is not yet supported. Only 'ollama' is available."
+        return jsonify({"error": msg}), 400
     model = settings.get("llm_model", DEFAULT_LLM_MODEL)
 
     memory = _get_memory()

--- a/static/app.js
+++ b/static/app.js
@@ -532,6 +532,9 @@ function _confirmLightboxRename() {
         // fingerprint stays unchanged — it's the stable identity key
         // (original macOS name + size), not a derived filename attribute.
         card.dataset.memoryStatus = "renamed";
+        card.dataset.suggestedName = "";
+        const badge = card.querySelector(".suggestion-badge");
+        if (badge) badge.remove();
         const cardImg = card.querySelector("img");
         cardImg.alt = newName;
         cardImg.src = `/api/thumb/${encodeURIComponent(newName)}?t=${Date.now()}`;
@@ -917,6 +920,9 @@ renameConfirm.addEventListener("click", () => {
       // fingerprint stays unchanged — it's the stable identity key
       // (original macOS name + size), not a derived filename attribute.
       renameTarget.dataset.memoryStatus = "renamed";
+      renameTarget.dataset.suggestedName = "";
+      const badge = renameTarget.querySelector(".suggestion-badge");
+      if (badge) badge.remove();
       const cardImg = renameTarget.querySelector("img");
       cardImg.alt = newName;
       cardImg.src = `/api/thumb/${encodeURIComponent(newName)}?t=${Date.now()}`;

--- a/static/app.js
+++ b/static/app.js
@@ -31,6 +31,7 @@ const sortSelect     = document.getElementById("sort-select");
 const suggestProgress   = document.getElementById("suggest-progress");
 const suggestProgressFill = document.getElementById("suggest-progress-fill");
 const suggestProgressText = document.getElementById("suggest-progress-text");
+const suggestCancelBtn  = document.getElementById("suggest-cancel-btn");
 
 const lightbox    = document.getElementById("lightbox");
 const lightboxImg = document.getElementById("lightbox-img");
@@ -607,6 +608,7 @@ function suggestSingle(card) {
 function suggestBatch(fingerprints) {
   if (fingerprints.length === 0) return;
 
+  _suggestCancelled = false;
   suggestAllBtn.disabled = true;
   suggestProgress.hidden = false;
   suggestProgressFill.style.width = "0%";
@@ -617,6 +619,11 @@ function suggestBatch(fingerprints) {
   let firstError = null;
 
   function processChunk(startIdx) {
+    if (_suggestCancelled) {
+      suggestProgressText.textContent = `Cancelled (${completed} processed)`;
+      setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 1500);
+      return;
+    }
     if (startIdx >= fingerprints.length) {
       suggestProgressFill.style.width = "100%";
       if (completed === 0 && firstError) {
@@ -755,6 +762,12 @@ function editSuggestion(card) {
     renameInput.setSelectionRange(0, dotIdx);
   }
 }
+
+// ── Cancel suggest button ────────────────────────────────────────────────────
+let _suggestCancelled = false;
+suggestCancelBtn.addEventListener("click", () => {
+  _suggestCancelled = true;
+});
 
 // ── Suggest All button ───────────────────────────────────────────────────────
 suggestAllBtn.addEventListener("click", () => {

--- a/static/app.js
+++ b/static/app.js
@@ -612,16 +612,27 @@ function suggestBatch(fingerprints) {
   suggestProgressFill.style.width = "0%";
   suggestProgressText.textContent = `0 / ${fingerprints.length}`;
 
-  // Process in chunks of 3 to show progress
-  const chunkSize = 1;  // Ollama processes sequentially anyway
+  const chunkSize = 1;
   let completed = 0;
+  let firstError = null;
 
   function processChunk(startIdx) {
     if (startIdx >= fingerprints.length) {
-      // All done
       suggestProgressFill.style.width = "100%";
-      suggestProgressText.textContent = `Done! ${completed} processed`;
-      setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 1500);
+      if (completed === 0 && firstError) {
+        suggestProgressText.textContent = firstError;
+        statusMsg.textContent = firstError;
+        setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 4000);
+      } else if (completed === 0) {
+        suggestProgressText.textContent = "No suggestions generated. Is Ollama running?";
+        setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 3000);
+      } else {
+        suggestProgressText.textContent = `Done! ${completed} processed`;
+        if (firstError) {
+          statusMsg.textContent = firstError;
+        }
+        setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 1500);
+      }
       return;
     }
 
@@ -634,25 +645,25 @@ function suggestBatch(fingerprints) {
     })
       .then(r => r.json())
       .then(data => {
+        // Check for backend-level error (e.g. unsupported provider)
+        if (data.error) {
+          if (!firstError) firstError = data.error;
+        }
         const suggestions = data.suggestions || {};
         for (const [fp, suggestedName] of Object.entries(suggestions)) {
           const card = document.querySelector(`[data-fingerprint="${CSS.escape(fp)}"]`);
           if (card) {
             card.dataset.memoryStatus = "suggested";
             card.dataset.suggestedName = suggestedName;
-            // Remove existing badge if any
             const oldBadge = card.querySelector(".suggestion-badge");
             if (oldBadge) oldBadge.remove();
-            // Insert badge after img, before card-actions
             const badge = _makeSuggestionBadge(card);
             const actions = card.querySelector(".card-actions");
             card.insertBefore(badge, actions);
-            // Rebuild action buttons (remove "Suggest" btn)
             setCardActions(card, getCardColumn(card));
           }
           completed++;
         }
-        // Update progress
         const nextIdx = startIdx + chunkSize;
         const pct = Math.round((Math.min(nextIdx, fingerprints.length) / fingerprints.length) * 100);
         suggestProgressFill.style.width = pct + "%";
@@ -660,7 +671,7 @@ function suggestBatch(fingerprints) {
         processChunk(nextIdx);
       })
       .catch(() => {
-        // On error, skip ahead
+        if (!firstError) firstError = "Couldn't reach Ollama — is it running?";
         const nextIdx = startIdx + chunkSize;
         processChunk(nextIdx);
       });

--- a/static/app.js
+++ b/static/app.js
@@ -20,12 +20,17 @@ const countUnsorted = document.getElementById("count-unsorted");
 const countTrash    = document.getElementById("count-trash");
 const countKeep     = document.getElementById("count-keep");
 
-const undoBtn   = document.getElementById("undo-btn");
-const doneBtn   = document.getElementById("done-btn");
-const statusMsg = document.getElementById("status-msg");
-const emptyMsg  = document.getElementById("empty-msg");
-const loadingMsg = document.getElementById("loading-msg");
-const sortSelect = document.getElementById("sort-select");
+const undoBtn        = document.getElementById("undo-btn");
+const doneBtn        = document.getElementById("done-btn");
+const suggestAllBtn  = document.getElementById("suggest-all-btn");
+const settingsBtn    = document.getElementById("settings-btn");
+const statusMsg      = document.getElementById("status-msg");
+const emptyMsg       = document.getElementById("empty-msg");
+const loadingMsg     = document.getElementById("loading-msg");
+const sortSelect     = document.getElementById("sort-select");
+const suggestProgress   = document.getElementById("suggest-progress");
+const suggestProgressFill = document.getElementById("suggest-progress-fill");
+const suggestProgressText = document.getElementById("suggest-progress-text");
 
 const lightbox    = document.getElementById("lightbox");
 const lightboxImg = document.getElementById("lightbox-img");
@@ -39,6 +44,13 @@ const confirmModal = document.getElementById("confirm-modal");
 const modalTitle   = document.getElementById("modal-title");
 const modalCancel  = document.getElementById("modal-cancel");
 const modalConfirm = document.getElementById("modal-confirm");
+
+const settingsModal   = document.getElementById("settings-modal");
+const settingsProvider = document.getElementById("settings-provider");
+const settingsModel   = document.getElementById("settings-model");
+const settingsAuto    = document.getElementById("settings-auto");
+const settingsCancel  = document.getElementById("settings-cancel");
+const settingsSave    = document.getElementById("settings-save");
 
 const renameModal   = document.getElementById("rename-modal");
 const renameInput   = document.getElementById("rename-input");
@@ -59,12 +71,24 @@ function sanitise(str) {
     .replace(/'/g, "&#39;");
 }
 
+// ── Settings state (loaded on init) ────────────────────────────────────────────
+let llmSettings = { llm_provider: "ollama", llm_model: "gemma4:e2b", auto_suggest: false };
+
+function loadSettings() {
+  return fetch("/api/settings")
+    .then(r => r.json())
+    .then(s => { llmSettings = s; })
+    .catch(() => {});
+}
+
 // ── Bootstrap ────────────────────────────────────────────────────────────────
 function init() {
-  fetch("/api/state")
-    .then(r => r.json())
-    .then(state => loadScreenshots(state.decisions || {}))
-    .catch(() => loadScreenshots({}));
+  loadSettings().then(() => {
+    fetch("/api/state")
+      .then(r => r.json())
+      .then(state => loadScreenshots(state.decisions || {}))
+      .catch(() => loadScreenshots({}));
+  });
 }
 
 function loadScreenshots(savedDecisions) {
@@ -93,10 +117,18 @@ function loadScreenshots(savedDecisions) {
         const target = col === "trash" ? cardsTrash
                      : col === "keep"  ? cardsKeep
                      : cardsUnsorted;
-        target.appendChild(makeCard(f.name, col, f.fingerprint, f.memory_status));
+        target.appendChild(makeCard(f.name, col, f.fingerprint, f.memory_status, f.suggested_name));
       });
       updateCounts();
       saveState();
+
+      // Auto-suggest if enabled
+      if (llmSettings.auto_suggest) {
+        const newFps = files
+          .filter(f => f.memory_status === "new")
+          .map(f => f.fingerprint);
+        if (newFps.length > 0) suggestBatch(newFps);
+      }
     })
     .catch(() => {
       loadingMsg.hidden = true;
@@ -133,7 +165,7 @@ function saveState() {
 }
 
 // ── Card factory ─────────────────────────────────────────────────────────────
-function makeCard(filename, column, fingerprint, memoryStatus) {
+function makeCard(filename, column, fingerprint, memoryStatus, suggestedName) {
   const card = document.createElement("article");
   card.className = "card";
   card.setAttribute("role", "listitem");
@@ -141,6 +173,7 @@ function makeCard(filename, column, fingerprint, memoryStatus) {
   card.dataset.filename = filename;
   card.dataset.fingerprint = fingerprint || "";
   card.dataset.memoryStatus = memoryStatus || "";
+  card.dataset.suggestedName = suggestedName || "";
   card.draggable = true;
   card.tabIndex = 0;
 
@@ -154,6 +187,12 @@ function makeCard(filename, column, fingerprint, memoryStatus) {
   actions.className = "card-actions";
 
   card.appendChild(img);
+
+  // Suggestion badge (always visible when status is "suggested")
+  if (memoryStatus === "suggested" && suggestedName) {
+    card.appendChild(_makeSuggestionBadge(card));
+  }
+
   card.appendChild(actions);
 
   setCardActions(card, column);
@@ -163,6 +202,45 @@ function makeCard(filename, column, fingerprint, memoryStatus) {
   attachTooltip(card);
 
   return card;
+}
+
+function _makeSuggestionBadge(card) {
+  const badge = document.createElement("div");
+  badge.className = "suggestion-badge";
+
+  const nameSpan = document.createElement("span");
+  nameSpan.className = "suggestion-badge-name";
+  nameSpan.textContent = card.dataset.suggestedName;
+  nameSpan.title = card.dataset.suggestedName;
+
+  const actionsDiv = document.createElement("div");
+  actionsDiv.className = "suggestion-badge-actions";
+
+  const acceptBtn = document.createElement("button");
+  acceptBtn.className = "suggestion-badge-btn accept";
+  acceptBtn.textContent = "✓";
+  acceptBtn.title = "Accept & rename";
+  acceptBtn.addEventListener("click", e => { e.stopPropagation(); acceptSuggestion(card); });
+
+  const rejectBtn = document.createElement("button");
+  rejectBtn.className = "suggestion-badge-btn reject";
+  rejectBtn.textContent = "✕";
+  rejectBtn.title = "Dismiss suggestion";
+  rejectBtn.addEventListener("click", e => { e.stopPropagation(); rejectSuggestion(card); });
+
+  const editBtn = document.createElement("button");
+  editBtn.className = "suggestion-badge-btn edit";
+  editBtn.textContent = "✎";
+  editBtn.title = "Edit & rename";
+  editBtn.addEventListener("click", e => { e.stopPropagation(); editSuggestion(card); });
+
+  actionsDiv.appendChild(acceptBtn);
+  actionsDiv.appendChild(rejectBtn);
+  actionsDiv.appendChild(editBtn);
+  badge.appendChild(nameSpan);
+  badge.appendChild(actionsDiv);
+
+  return badge;
 }
 
 // ── Card action buttons ──────────────────────────────────────────────────────
@@ -180,6 +258,14 @@ function setCardActions(card, column) {
     actions.appendChild(previewBtn);
     actions.appendChild(renameBtn);
     actions.appendChild(trashBtn);
+
+    // Show "✨ AI Suggest" for unprocessed files
+    if (card.dataset.memoryStatus === "new") {
+      const suggestBtn = makeActionBtn("✨ Suggest", "btn-suggest", () => suggestSingle(card));
+      // Insert after rename, before trash
+      const trashRef = actions.querySelector(".btn-trash");
+      if (trashRef) actions.insertBefore(suggestBtn, trashRef);
+    }
   } else {
     const undoBtn = makeActionBtn("\u21A9 Undo", "btn-undo", () => moveCard(card, "unsorted"));
     actions.appendChild(previewBtn);
@@ -498,12 +584,215 @@ document.addEventListener("keydown", e => {
     if (!lightbox.hidden) { closeLightbox(); return; }
     if (!confirmModal.hidden) { closeModal(); return; }
     if (!renameModal.hidden) { closeRenameModal(); return; }
+    if (!settingsModal.hidden) { closeSettingsModal(); return; }
   }
 
   if ((e.metaKey || e.ctrlKey) && e.key === "z") {
     e.preventDefault();
     performUndo();
   }
+});
+
+// ── AI Suggest (single card) ──────────────────────────────────────────────────
+function suggestSingle(card) {
+  const fp = card.dataset.fingerprint;
+  if (!fp) return;
+  suggestBatch([fp]);
+}
+
+// ── AI Suggest (batch) ──────────────────────────────────────────────────────
+function suggestBatch(fingerprints) {
+  if (fingerprints.length === 0) return;
+
+  suggestAllBtn.disabled = true;
+  suggestProgress.hidden = false;
+  suggestProgressFill.style.width = "0%";
+  suggestProgressText.textContent = `0 / ${fingerprints.length}`;
+
+  // Process in chunks of 3 to show progress
+  const chunkSize = 1;  // Ollama processes sequentially anyway
+  let completed = 0;
+
+  function processChunk(startIdx) {
+    if (startIdx >= fingerprints.length) {
+      // All done
+      suggestProgressFill.style.width = "100%";
+      suggestProgressText.textContent = `Done! ${completed} processed`;
+      setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 1500);
+      return;
+    }
+
+    const chunk = fingerprints.slice(startIdx, startIdx + chunkSize);
+
+    fetch("/api/suggest-names", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fingerprints: chunk }),
+    })
+      .then(r => r.json())
+      .then(data => {
+        const suggestions = data.suggestions || {};
+        for (const [fp, suggestedName] of Object.entries(suggestions)) {
+          const card = document.querySelector(`[data-fingerprint="${CSS.escape(fp)}"]`);
+          if (card) {
+            card.dataset.memoryStatus = "suggested";
+            card.dataset.suggestedName = suggestedName;
+            // Remove existing badge if any
+            const oldBadge = card.querySelector(".suggestion-badge");
+            if (oldBadge) oldBadge.remove();
+            // Insert badge after img, before card-actions
+            const badge = _makeSuggestionBadge(card);
+            const actions = card.querySelector(".card-actions");
+            card.insertBefore(badge, actions);
+            // Rebuild action buttons (remove "Suggest" btn)
+            setCardActions(card, getCardColumn(card));
+          }
+          completed++;
+        }
+        // Update progress
+        const nextIdx = startIdx + chunkSize;
+        const pct = Math.round((Math.min(nextIdx, fingerprints.length) / fingerprints.length) * 100);
+        suggestProgressFill.style.width = pct + "%";
+        suggestProgressText.textContent = `${Math.min(nextIdx, fingerprints.length)} / ${fingerprints.length}`;
+        processChunk(nextIdx);
+      })
+      .catch(() => {
+        // On error, skip ahead
+        const nextIdx = startIdx + chunkSize;
+        processChunk(nextIdx);
+      });
+  }
+
+  processChunk(0);
+}
+
+// ── Accept suggestion (rename file to suggested name) ───────────────────────
+function acceptSuggestion(card) {
+  const fp = card.dataset.fingerprint;
+  if (!fp) return;
+
+  fetch("/api/accept-suggestion", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fingerprint: fp }),
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (!data.ok) {
+        alert(data.error || "Failed to accept suggestion");
+        return;
+      }
+      const oldName = card.dataset.filename;
+      const newName = data.new_name;
+      const col = getCardColumn(card);
+      if (col === "unsorted") {
+        decisions.delete(oldName);
+      } else {
+        decisions.delete(oldName);
+        decisions.set(newName, col);
+      }
+      card.dataset.filename = newName;
+      card.dataset.memoryStatus = "renamed";
+      card.dataset.suggestedName = "";
+      const cardImg = card.querySelector("img");
+      cardImg.alt = newName;
+      cardImg.src = `/api/thumb/${encodeURIComponent(newName)}?t=${Date.now()}`;
+      // Remove badge
+      const badge = card.querySelector(".suggestion-badge");
+      if (badge) badge.remove();
+      setCardActions(card, col);
+      updateCounts();
+      saveState();
+    })
+    .catch(() => alert("Network error — please try again."));
+}
+
+// ── Reject suggestion (dismiss, mark as ignored) ─────────────────────────────
+function rejectSuggestion(card) {
+  const fp = card.dataset.fingerprint;
+  if (!fp) return;
+
+  fetch("/api/reject-suggestion", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fingerprint: fp }),
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (!data.ok) return;
+      card.dataset.memoryStatus = "ignored";
+      card.dataset.suggestedName = "";
+      const badge = card.querySelector(".suggestion-badge");
+      if (badge) badge.remove();
+      setCardActions(card, getCardColumn(card));
+    })
+    .catch(() => {});
+}
+
+// ── Edit suggestion (open rename modal pre-filled with suggested name) ────────
+function editSuggestion(card) {
+  renameTarget = card;
+  renameInput.value = card.dataset.suggestedName || card.dataset.filename;
+  renameError.textContent = "";
+  renameModal.hidden = false;
+  const dotIdx = renameInput.value.lastIndexOf(".");
+  renameInput.focus();
+  if (dotIdx > 0) {
+    renameInput.setSelectionRange(0, dotIdx);
+  }
+}
+
+// ── Suggest All button ───────────────────────────────────────────────────────
+suggestAllBtn.addEventListener("click", () => {
+  const newFps = [...document.querySelectorAll(".card")]
+    .filter(c => c.dataset.memoryStatus === "new")
+    .map(c => c.dataset.fingerprint)
+    .filter(Boolean);
+  if (newFps.length === 0) {
+    statusMsg.textContent = "No new screenshots to suggest names for.";
+    return;
+  }
+  suggestBatch(newFps);
+});
+
+// ── Settings modal ────────────────────────────────────────────────────────────
+settingsBtn.addEventListener("click", () => {
+  // Load current settings into form
+  settingsProvider.value = llmSettings.llm_provider || "ollama";
+  settingsModel.value = llmSettings.llm_model || "gemma4:e2b";
+  settingsAuto.checked = llmSettings.auto_suggest || false;
+  settingsModal.hidden = false;
+});
+
+function closeSettingsModal() {
+  settingsModal.hidden = true;
+}
+
+settingsCancel.addEventListener("click", closeSettingsModal);
+settingsModal.addEventListener("click", e => {
+  if (e.target === settingsModal) closeSettingsModal();
+});
+
+settingsSave.addEventListener("click", () => {
+  const newSettings = {
+    llm_provider: settingsProvider.value,
+    llm_model: settingsModel.value.trim() || "gemma4:e2b",
+    auto_suggest: settingsAuto.checked,
+  };
+
+  fetch("/api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(newSettings),
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (data.ok) {
+        llmSettings = newSettings;
+        closeSettingsModal();
+      }
+    })
+    .catch(() => {});
 });
 
 // ── Undo ─────────────────────────────────────────────────────────────────────

--- a/static/style.css
+++ b/static/style.css
@@ -40,6 +40,44 @@ header h1 {
   gap: 14px;
 }
 
+.header-suggest-btn {
+  padding: 8px 18px;
+  border: none;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #af52de, #5856d6);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.1s;
+}
+
+.header-suggest-btn:hover {
+  opacity: 0.9;
+  transform: scale(1.02);
+}
+
+.header-suggest-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.header-settings-btn {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 8px;
+  background: #f0f0f0;
+  color: #333;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.header-settings-btn:hover {
+  background: #e0e0e0;
+}
+
 #status-msg {
   font-size: 0.85rem;
   color: #666;
@@ -257,13 +295,15 @@ header h1 {
   position: absolute;
   inset: 0;
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   opacity: 0;
   transition: opacity 0.15s;
   pointer-events: none;
   background: rgba(0, 0, 0, 0.25);
+  padding: 8px;
 }
 
 .card:hover .card-actions {
@@ -333,6 +373,38 @@ header h1 {
   background: #0062cc;
 }
 
+.btn-suggest {
+  background: rgba(175, 82, 222, 0.9);
+}
+
+.btn-suggest:hover {
+  background: #8b3fba;
+}
+
+.btn-accept {
+  background: rgba(52, 199, 89, 0.9);
+}
+
+.btn-accept:hover {
+  background: #2db84e;
+}
+
+.btn-reject {
+  background: rgba(255, 149, 0, 0.9);
+}
+
+.btn-reject:hover {
+  background: #e08600;
+}
+
+.btn-suggest-edit {
+  background: rgba(0, 122, 255, 0.85);
+}
+
+.btn-suggest-edit:hover {
+  background: #0062cc;
+}
+
 /* ── Rename modal ────────────────────────────────────────── */
 .rename-input {
   width: 100%;
@@ -389,6 +461,150 @@ header h1 {
 
 .card-tooltip.visible {
   opacity: 1;
+}
+
+/* ── Suggestion badge (below card image) ────────────────── */
+.suggestion-badge {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  background: #f3e8ff;
+  border-top: 1px solid #e0d0f0;
+  font-size: 0.72rem;
+}
+
+.suggestion-badge-name {
+  flex: 1 1 auto;
+  color: #6b21a8;
+  font-weight: 600;
+  font-family: "SF Mono", "Menlo", "Consolas", monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 60px;
+}
+
+.suggestion-badge-actions {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.suggestion-badge-btn {
+  padding: 2px 8px;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  transition: transform 0.1s;
+}
+
+.suggestion-badge-btn:hover {
+  transform: scale(1.05);
+}
+
+.suggestion-badge-btn.accept {
+  background: #34c759;
+}
+
+.suggestion-badge-btn.reject {
+  background: #ff9500;
+}
+
+.suggestion-badge-btn.edit {
+  background: #007aff;
+}
+
+/* ── Suggest progress bar ───────────────────────────────── */
+.suggest-progress {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 24px;
+  background: #f0e6ff;
+  border-bottom: 1px solid #e0d0f0;
+  flex-shrink: 0;
+}
+
+.suggest-progress-bar {
+  flex: 1;
+  height: 6px;
+  background: #e0d0f0;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.suggest-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(135deg, #af52de, #5856d6);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.suggest-progress-text {
+  font-size: 0.8rem;
+  color: #6b21a8;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* ── Settings modal ─────────────────────────────────────── */
+.settings-form {
+  text-align: left;
+  margin-bottom: 20px;
+}
+
+.settings-field {
+  margin-bottom: 14px;
+}
+
+.settings-field label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.settings-field select,
+.settings-field input[type="text"] {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.settings-field select:focus,
+.settings-field input[type="text"]:focus {
+  border-color: #007aff;
+  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.15);
+}
+
+.settings-field-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.settings-field-toggle label {
+  margin-bottom: 0;
+}
+
+.settings-field-toggle input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #007aff;
 }
 
 /* ── Empty state ─────────────────────────────────────────── */

--- a/static/style.css
+++ b/static/style.css
@@ -553,6 +553,23 @@ header h1 {
   white-space: nowrap;
 }
 
+.suggest-cancel-btn {
+  padding: 4px 12px;
+  border: 1px solid #d0c0e0;
+  border-radius: 6px;
+  background: #fff;
+  color: #6b21a8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+
+.suggest-cancel-btn:hover {
+  background: #f0e6ff;
+}
+
 /* ── Settings modal ─────────────────────────────────────── */
 .settings-form {
   text-align: left;

--- a/static/style.css
+++ b/static/style.css
@@ -607,6 +607,14 @@ header h1 {
   accent-color: #007aff;
 }
 
+.settings-save-btn {
+  background: #007aff;
+}
+
+.settings-save-btn:hover {
+  background: #0062cc;
+}
+
 /* ── Empty state ─────────────────────────────────────────── */
 #empty-msg {
   text-align: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,6 +93,7 @@
       <div class="suggest-progress-fill" id="suggest-progress-fill"></div>
     </div>
     <span class="suggest-progress-text" id="suggest-progress-text"></span>
+    <button id="suggest-cancel-btn" class="suggest-cancel-btn" aria-label="Cancel suggestions">Cancel</button>
   </div>
 
   <!-- Rename modal -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,8 +20,10 @@
         <option value="size">Smallest first</option>
         <option value="size_desc">Largest first</option>
       </select>
+      <button id="suggest-all-btn" class="header-suggest-btn" aria-label="Suggest names for all new screenshots">✨ Suggest All</button>
       <button id="undo-btn" disabled aria-label="Undo last move">Undo</button>
       <button id="done-btn" disabled aria-label="Move screenshots to trash">Done</button>
+      <button id="settings-btn" class="header-settings-btn" aria-label="Open settings">⚙</button>
     </div>
   </header>
 
@@ -85,6 +87,14 @@
     </div>
   </div>
 
+  <!-- Suggest progress bar -->
+  <div id="suggest-progress" class="suggest-progress" hidden>
+    <div class="suggest-progress-bar">
+      <div class="suggest-progress-fill" id="suggest-progress-fill"></div>
+    </div>
+    <span class="suggest-progress-text" id="suggest-progress-text"></span>
+  </div>
+
   <!-- Rename modal -->
   <div id="rename-modal" class="modal-overlay" hidden role="dialog" aria-labelledby="rename-title">
     <div class="modal">
@@ -95,6 +105,34 @@
       <div class="modal-actions">
         <button class="modal-btn modal-cancel" id="rename-cancel">Cancel</button>
         <button class="modal-btn modal-confirm rename-confirm-btn" id="rename-confirm">Rename</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Settings modal -->
+  <div id="settings-modal" class="modal-overlay" hidden role="dialog" aria-labelledby="settings-title">
+    <div class="modal">
+      <p class="modal-title" id="settings-title">Settings</p>
+      <div class="settings-form">
+        <div class="settings-field">
+          <label for="settings-provider">LLM Provider</label>
+          <select id="settings-provider">
+            <option value="ollama">Ollama</option>
+            <option value="mlx">MLX</option>
+          </select>
+        </div>
+        <div class="settings-field">
+          <label for="settings-model">Model</label>
+          <input id="settings-model" type="text" class="rename-input" autocomplete="off" spellcheck="false" placeholder="gemma4:e2b" />
+        </div>
+        <div class="settings-field settings-field-toggle">
+          <label for="settings-auto">Auto-suggest on scan</label>
+          <input id="settings-auto" type="checkbox" />
+        </div>
+      </div>
+      <div class="modal-actions">
+        <button class="modal-btn modal-cancel" id="settings-cancel">Cancel</button>
+        <button class="modal-btn modal-confirm" id="settings-save" style="background:#007aff">Save</button>
       </div>
     </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -118,7 +118,7 @@
           <label for="settings-provider">LLM Provider</label>
           <select id="settings-provider">
             <option value="ollama">Ollama</option>
-            <option value="mlx">MLX</option>
+            <option value="mlx" disabled>MLX (coming soon)</option>
           </select>
         </div>
         <div class="settings-field">

--- a/templates/index.html
+++ b/templates/index.html
@@ -132,7 +132,7 @@
       </div>
       <div class="modal-actions">
         <button class="modal-btn modal-cancel" id="settings-cancel">Cancel</button>
-        <button class="modal-btn modal-confirm" id="settings-save" style="background:#007aff">Save</button>
+        <button class="modal-btn modal-confirm settings-save-btn" id="settings-save">Save</button>
       </div>
     </div>
   </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(flask_app, "THUMB_DIR", thumb_dir)
     monkeypatch.setattr(flask_app, "STATE_FILE", tmp_path / "state.json")
     monkeypatch.setattr(flask_app, "MEMORY_FILE", tmp_path / "memory.json")
+    monkeypatch.setattr(flask_app, "SETTINGS_FILE", tmp_path / "settings.json")
     flask_app._reset_memory()
     flask_app.app.config["TESTING"] = True
     with flask_app.app.test_client() as c:

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -128,3 +128,100 @@ def test_app_js_updates_memory_status_on_rename(client):
     r = c.get("/static/app.js")
     assert r.status_code == 200
     assert b'memoryStatus = "renamed"' in r.data
+
+
+# ── Phase 3 UI elements ─────────────────────────────────────────────────
+
+
+def test_index_has_suggest_all_button(client):
+    c, _ = client
+    html = c.get("/").data.decode()
+    assert 'id="suggest-all-btn"' in html
+    assert "Suggest All" in html
+
+
+def test_index_has_settings_button(client):
+    c, _ = client
+    html = c.get("/").data.decode()
+    assert 'id="settings-btn"' in html
+
+
+def test_index_has_suggest_progress_bar(client):
+    c, _ = client
+    html = c.get("/").data.decode()
+    assert 'id="suggest-progress"' in html
+    assert 'id="suggest-progress-fill"' in html
+    assert 'id="suggest-progress-text"' in html
+
+
+def test_index_has_settings_modal(client):
+    c, _ = client
+    html = c.get("/").data.decode()
+    assert 'id="settings-modal"' in html
+    assert 'id="settings-provider"' in html
+    assert 'id="settings-model"' in html
+    assert 'id="settings-auto"' in html
+
+
+def test_app_js_defines_suggest_batch(client):
+    """JS must define suggestBatch function for batch LLM suggestions."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"function suggestBatch(" in r.data
+
+
+def test_app_js_defines_accept_suggestion(client):
+    """JS must define acceptSuggestion for accepting LLM suggestions."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"function acceptSuggestion(" in r.data
+
+
+def test_app_js_defines_reject_suggestion(client):
+    """JS must define rejectSuggestion for dismissing LLM suggestions."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"function rejectSuggestion(" in r.data
+
+
+def test_app_js_defines_settings_modal(client):
+    """JS must handle settings modal."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"settingsModal" in r.data
+
+
+def test_app_js_has_suggestion_badge_maker(client):
+    """JS must have _makeSuggestionBadge for rendering suggested name with accept/reject."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"_makeSuggestionBadge" in r.data
+
+
+def test_css_has_suggestion_badge_styles(client):
+    """CSS must define styles for suggestion badge."""
+    c, _ = client
+    r = c.get("/static/style.css")
+    assert r.status_code == 200
+    assert b"suggestion-badge" in r.data
+
+
+def test_css_has_suggest_progress_styles(client):
+    """CSS must define styles for progress bar."""
+    c, _ = client
+    r = c.get("/static/style.css")
+    assert r.status_code == 200
+    assert b"suggest-progress" in r.data
+
+
+def test_css_has_settings_form_styles(client):
+    """CSS must define styles for settings form."""
+    c, _ = client
+    r = c.get("/static/style.css")
+    assert r.status_code == 200
+    assert b"settings-form" in r.data

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -161,6 +161,7 @@ def test_index_has_settings_modal(client):
     assert 'id="settings-provider"' in html
     assert 'id="settings-model"' in html
     assert 'id="settings-auto"' in html
+    assert "coming soon" in html.lower()  # MLX option marked as disabled
 
 
 def test_app_js_defines_suggest_batch(client):

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -228,6 +228,21 @@ def test_css_has_settings_form_styles(client):
     assert b"settings-form" in r.data
 
 
+def test_index_has_suggest_cancel_button(client):
+    """Progress bar must have a cancel button."""
+    c, _ = client
+    html = c.get("/").data.decode()
+    assert 'id="suggest-cancel-btn"' in html
+
+
+def test_app_js_has_cancel_logic(client):
+    """JS must define _suggestCancelled flag for cancel support."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"_suggestCancelled" in r.data
+
+
 def test_rename_handlers_remove_suggestion_badge(client):
     """Both rename paths (modal + lightbox) must remove .suggestion-badge after rename."""
     c, _ = client

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -225,3 +225,14 @@ def test_css_has_settings_form_styles(client):
     r = c.get("/static/style.css")
     assert r.status_code == 200
     assert b"settings-form" in r.data
+
+
+def test_rename_handlers_remove_suggestion_badge(client):
+    """Both rename paths (modal + lightbox) must remove .suggestion-badge after rename."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    # Lightbox rename
+    assert b"if (badge) badge.remove()" in r.data
+    # Modal rename sets suggestedName to empty
+    assert b'suggestedName = ""' in r.data

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -496,8 +496,8 @@ def test_suggest_names_with_real_file_and_mock_llm(client, monkeypatch):
     assert json.loads(r.data)[0]["memory_status"] == "new"
 
     # Mock the Ollama call
-    def mock_suggest(image_path, model):
-        return "customer-onboarding.png"
+    def mock_suggest(image_path, model, extension=".png"):
+        return "customer-onboarding" + extension
 
     monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
 
@@ -535,10 +535,10 @@ def test_suggest_names_skips_already_processed(client, monkeypatch):
 
     call_count = 0
 
-    def mock_suggest(image_path, model):
+    def mock_suggest(image_path, model, extension=".png"):
         nonlocal call_count
         call_count += 1
-        return "should-not-be-called.png"
+        return "should-not-be-called" + extension
 
     monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
 
@@ -561,7 +561,7 @@ def test_suggest_names_handles_llm_returning_none(client, monkeypatch):
     r = c.get("/api/screenshots")
     fp = json.loads(r.data)[0]["fingerprint"]
 
-    def mock_suggest(image_path, model):
+    def mock_suggest(image_path, model, extension=".png"):
         return None
 
     monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
@@ -833,3 +833,53 @@ def test_call_ollama_suggest_sanitizes_filename(tmp_path, monkeypatch):
 
     result = flask_app._call_ollama_suggest(img, "test-model")
     assert result == "hello-world-this-is-great.png"
+
+
+def test_call_ollama_suggest_preserves_extension(tmp_path, monkeypatch):
+    """The extension parameter is used, not hardcoded .png."""
+    import json as _json
+
+    img = tmp_path / "test.jpg"
+    img.write_bytes(b"fake-jpg-data")
+
+    class FakeResponse:
+        def read(self):
+            return _json.dumps({"message": {"content": "sunny beach"}}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    monkeypatch.setattr(
+        flask_app.urllib.request, "urlopen", lambda req, timeout=None: FakeResponse()
+    )
+
+    result = flask_app._call_ollama_suggest(img, "test-model", extension=".jpg")
+    assert result == "sunny-beach.jpg"
+
+
+def test_suggest_names_preserves_non_png_extension(client, monkeypatch):
+    """When a .jpg file gets a suggestion, the suggested name keeps .jpg."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.jpg"
+    f.write_bytes(b"jpg-data")
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    def mock_suggest(image_path, model, extension=".png"):
+        # Verify extension was passed correctly
+        assert extension == ".jpg"
+        return "beach-photo" + extension
+
+    monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
+
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": [fp]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data)["suggestions"][fp] == "beach-photo.jpg"

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -872,6 +872,24 @@ def test_settings_put_ignores_unknown_keys(client):
     assert data["llm_model"] == "test"
 
 
+def test_suggest_names_rejects_non_ollama_provider(client):
+    """When provider is set to 'mlx', the endpoint should reject with a clear message."""
+    c, _ = client
+    c.put(
+        "/api/settings",
+        data=json.dumps({"llm_provider": "mlx"}),
+        content_type="application/json",
+    )
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": ["fp1"]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+    data = json.loads(r.data)
+    assert "not yet supported" in data["error"]
+
+
 # ── _call_ollama_suggest sanitization ────────────────────────────────────
 
 

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -450,3 +450,386 @@ def test_done_does_not_mark_ghost_file_as_trashed_in_memory(client):
     ghost = memory.lookup(ghost_fp)
     assert ghost is not None
     assert ghost.status == "new", f"Ghost file should still be 'new', got {ghost.status!r}"
+
+
+# ── /api/screenshots → suggested_name field ───────────────────────────────
+
+
+def test_screenshots_includes_suggested_name_when_available(client):
+    c, desktop = client
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"data")
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    memory = flask_app._get_memory()
+    memory.update_suggestion(fp, "my-suggested-name.png")
+    memory.save()
+    flask_app._reset_memory()
+
+    r2 = c.get("/api/screenshots")
+    file_data = json.loads(r2.data)[0]
+    assert file_data["suggested_name"] == "my-suggested-name.png"
+
+
+def test_screenshots_suggested_name_null_when_not_suggested(client):
+    c, desktop = client
+    (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").write_bytes(b"data")
+
+    r = c.get("/api/screenshots")
+    file_data = json.loads(r.data)[0]
+    assert file_data["suggested_name"] is None
+
+
+# ── /api/suggest-names (with real LLM mock) ────────────────────────────────
+
+
+def test_suggest_names_with_real_file_and_mock_llm(client, monkeypatch):
+    """When a real file exists and the LLM returns a name, suggestions are populated."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    # First scan to record the file
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+    assert json.loads(r.data)[0]["memory_status"] == "new"
+
+    # Mock the Ollama call
+    def mock_suggest(image_path, model):
+        return "customer-onboarding.png"
+
+    monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
+
+    # Now suggest names
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": [fp]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    result = json.loads(r.data)
+    assert result["suggestions"] == {fp: "customer-onboarding.png"}
+
+    # Memory should be updated
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    assert rec.status == "suggested"
+    assert rec.suggested_name == "customer-onboarding.png"
+
+
+def test_suggest_names_skips_already_processed(client, monkeypatch):
+    """Files that aren't 'new' should not be re-processed."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    # Set to ignored
+    memory = flask_app._get_memory()
+    memory.reject_suggestion(fp)
+    memory.save()
+    flask_app._reset_memory()
+
+    call_count = 0
+
+    def mock_suggest(image_path, model):
+        nonlocal call_count
+        call_count += 1
+        return "should-not-be-called.png"
+
+    monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
+
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": [fp]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data) == {"suggestions": {}}
+    assert call_count == 0  # LLM never called for ignored files
+
+
+def test_suggest_names_handles_llm_returning_none(client, monkeypatch):
+    """When the LLM returns None (error), the file is skipped gracefully."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    def mock_suggest(image_path, model):
+        return None
+
+    monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
+
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": [fp]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data) == {"suggestions": {}}
+
+    # Status should remain "new" (unchanged)
+    memory = flask_app._get_memory()
+    assert memory.lookup(fp).status == "new"
+
+
+def test_suggest_names_unknown_fingerprint_skipped(client, monkeypatch):
+    c, _ = client
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": ["bogus|123"]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data) == {"suggestions": {}}
+
+
+# ── /api/accept-suggestion ─────────────────────────────────────────────────
+
+
+def test_accept_suggestion_renames_file(client):
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    memory = flask_app._get_memory()
+    memory.update_suggestion(fp, "accepted-name.png")
+    memory.save()
+
+    r = c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({"fingerprint": fp}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    data = json.loads(r.data)
+    assert data["ok"] is True
+    assert data["new_name"] == "accepted-name.png"
+    assert data["old_name"] == "Screenshot 2024-01-01 at 12.00.00 PM.png"
+
+    # File should be renamed on disk
+    assert not (desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png").exists()
+    assert (desktop / "accepted-name.png").exists()
+
+    # Memory should reflect rename
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    assert rec.status == "renamed"
+    assert rec.last_known_name == "accepted-name.png"
+
+
+def test_accept_suggestion_handles_name_conflict(client):
+    """When suggested name already exists, append a counter."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+    (desktop / "conflict.png").write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    memory = flask_app._get_memory()
+    memory.update_suggestion(fp, "conflict.png")
+    memory.save()
+
+    r = c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({"fingerprint": fp}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    data = json.loads(r.data)
+    assert data["ok"] is True
+    # Should append -2 to avoid conflict
+    assert data["new_name"] == "conflict-2.png"
+    assert (desktop / "conflict-2.png").exists()
+
+
+def test_accept_suggestion_unknown_fingerprint(client):
+    c, _ = client
+    r = c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({"fingerprint": "nope|99"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 404
+    assert json.loads(r.data)["ok"] is False
+
+
+def test_accept_suggestion_no_suggestion_set(client):
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    r = c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({"fingerprint": fp}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+def test_accept_suggestion_missing_fingerprint_field(client):
+    c, _ = client
+    r = c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+# ── /api/reject-suggestion ─────────────────────────────────────────────────
+
+
+def test_reject_suggestion_marks_as_ignored(client):
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    memory = flask_app._get_memory()
+    memory.update_suggestion(fp, "some-name.png")
+    memory.save()
+
+    r = c.post(
+        "/api/reject-suggestion",
+        data=json.dumps({"fingerprint": fp}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data)["ok"] is True
+
+    memory = flask_app._get_memory()
+    assert memory.lookup(fp).status == "ignored"
+
+
+def test_reject_suggestion_unknown_fingerprint(client):
+    c, _ = client
+    r = c.post(
+        "/api/reject-suggestion",
+        data=json.dumps({"fingerprint": "nope|99"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 404
+
+
+def test_reject_suggestion_missing_fingerprint_field(client):
+    c, _ = client
+    r = c.post(
+        "/api/reject-suggestion",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+# ── /api/settings ──────────────────────────────────────────────────────────
+
+
+def test_settings_get_returns_defaults(client):
+    c, _ = client
+    r = c.get("/api/settings")
+    assert r.status_code == 200
+    data = json.loads(r.data)
+    assert data["llm_provider"] == "ollama"
+    assert data["llm_model"] == "gemma4:e2b"
+    assert data["auto_suggest"] is False
+
+
+def test_settings_put_and_get_roundtrip(client):
+    c, _ = client
+    r = c.put(
+        "/api/settings",
+        data=json.dumps({"llm_model": "qwen2.5:1.5b", "auto_suggest": True}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert json.loads(r.data)["ok"] is True
+
+    r = c.get("/api/settings")
+    data = json.loads(r.data)
+    assert data["llm_model"] == "qwen2.5:1.5b"
+    assert data["auto_suggest"] is True
+    assert data["llm_provider"] == "ollama"  # unchanged
+
+
+def test_settings_persists_to_disk(client):
+    c, _ = client
+    c.put(
+        "/api/settings",
+        data=json.dumps({"llm_model": "persist-test"}),
+        content_type="application/json",
+    )
+
+    settings_file = flask_app.SETTINGS_FILE
+    assert settings_file.exists()
+    raw = json.loads(settings_file.read_text())
+    assert raw["llm_model"] == "persist-test"
+
+
+def test_settings_put_rejects_non_json(client):
+    c, _ = client
+    r = c.put("/api/settings", data="not json", content_type="text/plain")
+    assert r.status_code == 400
+
+
+def test_settings_put_ignores_unknown_keys(client):
+    c, _ = client
+    c.put(
+        "/api/settings",
+        data=json.dumps({"llm_model": "test", "evil_key": "hacked", "auto_suggest": True}),
+        content_type="application/json",
+    )
+    r = c.get("/api/settings")
+    data = json.loads(r.data)
+    assert "evil_key" not in data
+    assert data["llm_model"] == "test"
+
+
+# ── _call_ollama_suggest sanitization ────────────────────────────────────
+
+
+def test_call_ollama_suggest_sanitizes_filename(tmp_path, monkeypatch):
+    """Verify the sanitization logic produces safe filenames."""
+    import json as _json
+
+    # Create a fake image file
+    img = tmp_path / "test.png"
+    img.write_bytes(b"fake-png-data")
+
+    # Mock urllib to return a raw LLM response
+    class FakeResponse:
+        def read(self):
+            return _json.dumps(
+                {
+                    "message": {"content": "  Hello World! This is GREAT  "},
+                }
+            ).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def mock_urlopen(req, timeout=None):
+        return FakeResponse()
+
+    monkeypatch.setattr(flask_app.urllib.request, "urlopen", mock_urlopen)
+
+    result = flask_app._call_ollama_suggest(img, "test-model")
+    assert result == "hello-world-this-is-great.png"

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -690,6 +690,78 @@ def test_accept_suggestion_missing_fingerprint_field(client):
     assert r.status_code == 400
 
 
+def test_accept_suggestion_empty_old_name_rejected(client):
+    """A corrupt memory record with empty last_known_name must not rename Desktop."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    memory = flask_app._get_memory()
+    # Corrupt the record: set last_known_name to empty string
+    rec = memory.lookup(fp)
+    rec.last_known_name = ""
+    rec.original_name = ""
+    rec.suggested_name = "evil.png"
+    memory.save()
+
+    r = c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({"fingerprint": fp}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+    assert "invalid filename" in json.loads(r.data)["error"]
+
+
+def test_accept_suggestion_path_traversal_rejected(client):
+    """Accept-suggestion must validate old_name against path traversal."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    rec.last_known_name = "../../../etc/passwd"
+    rec.suggested_name = "safe-name.png"
+    memory.save()
+
+    r = c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({"fingerprint": fp}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+    assert "invalid old_name" in json.loads(r.data)["error"]
+
+
+def test_accept_suggestion_directory_not_file_rejected(client):
+    """If old_path is a directory (not a file), reject with 404."""
+    c, desktop = client
+    subdir = desktop / "Screenshot subdir"
+    subdir.mkdir()
+
+    # Create a memory record pointing to a directory
+    memory = flask_app._get_memory()
+    rec = memory.record_file("Screenshot subdir", 0)
+    rec.suggested_name = "safe-name.png"
+    rec.last_known_name = "Screenshot subdir"
+    rec.original_name = "Screenshot subdir"
+    memory.save()
+
+    r = c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({"fingerprint": rec.fingerprint}),
+        content_type="application/json",
+    )
+    assert r.status_code == 404
+
+
 # ── /api/reject-suggestion ─────────────────────────────────────────────────
 
 

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -897,17 +897,13 @@ def test_call_ollama_suggest_sanitizes_filename(tmp_path, monkeypatch):
     """Verify the sanitization logic produces safe filenames."""
     import json as _json
 
-    # Create a fake image file
     img = tmp_path / "test.png"
     img.write_bytes(b"fake-png-data")
 
-    # Mock urllib to return a raw LLM response
     class FakeResponse:
         def read(self):
             return _json.dumps(
-                {
-                    "message": {"content": "  Hello World! This is GREAT  "},
-                }
+                {"message": {"content": "  Hello World! This is GREAT  "}},
             ).encode()
 
         def __enter__(self):
@@ -923,6 +919,66 @@ def test_call_ollama_suggest_sanitizes_filename(tmp_path, monkeypatch):
 
     result = flask_app._call_ollama_suggest(img, "test-model")
     assert result == "hello-world-this-is-great.png"
+
+
+def test_call_ollama_suggest_collapses_repeated_hyphens(tmp_path, monkeypatch):
+    """Multi-space / punctuation gaps should not produce '--'."""
+    import json as _json
+
+    img = tmp_path / "test.png"
+    img.write_bytes(b"fake-data")
+
+    class FakeResponse:
+        def read(self):
+            return _json.dumps(
+                {"message": {"content": "foo   bar!!!baz"}},
+            ).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    monkeypatch.setattr(
+        flask_app.urllib.request, "urlopen", lambda req, timeout=None: FakeResponse()
+    )
+
+    result = flask_app._call_ollama_suggest(img, "test-model")
+    # "foo   bar!!!baz" → "foo---barbaz" → collapsed to "foo-barbaz"
+    assert result == "foo-barbaz.png"
+    assert "--" not in result
+
+
+def test_call_ollama_suggest_strips_trailing_hyphen_after_truncation(tmp_path, monkeypatch):
+    """Truncation must not leave a trailing hyphen."""
+    import json as _json
+
+    img = tmp_path / "test.png"
+    img.write_bytes(b"fake-data")
+
+    # A long string where the 120-char slice cuts right after a hyphen
+    long_text = "a" * 119 + "-b"
+
+    class FakeResponse:
+        def read(self):
+            return _json.dumps(
+                {"message": {"content": long_text}},
+            ).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    monkeypatch.setattr(
+        flask_app.urllib.request, "urlopen", lambda req, timeout=None: FakeResponse()
+    )
+
+    result = flask_app._call_ollama_suggest(img, "test-model")
+    assert not result.startswith("-")
+    assert not result.rstrip(".png").endswith("-")
 
 
 def test_call_ollama_suggest_preserves_extension(tmp_path, monkeypatch):

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -254,7 +254,8 @@ def test_done_handles_files_not_in_memory(client):
 # ── /api/suggest-names (stub) ──────────────────────────────────────────────
 
 
-def test_suggest_names_stub_returns_empty(client):
+def test_suggest_names_unknown_fingerprints_return_empty(client):
+    """Fingerprints not in memory produce no suggestions (no crash)."""
     c, _ = client
     r = c.post(
         "/api/suggest-names",
@@ -870,6 +871,24 @@ def test_settings_put_ignores_unknown_keys(client):
     data = json.loads(r.data)
     assert "evil_key" not in data
     assert data["llm_model"] == "test"
+
+
+def test_settings_put_rejects_wrong_types(client):
+    """auto_suggest must be a bool, llm_model must be a string."""
+    c, _ = client
+    r = c.put(
+        "/api/settings",
+        data=json.dumps({"auto_suggest": "yes"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+    r = c.put(
+        "/api/settings",
+        data=json.dumps({"llm_model": 123}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
 
 
 def test_suggest_names_rejects_non_ollama_provider(client):


### PR DESCRIPTION
## Summary

Phase 3 of the [LLM Smart Rename Prerequisites Plan](https://github.com/Collaboration95/screenshot-declutterer/blob/add-llm/docs/design-llm-rename-prerequisites.md#phase-3-ui-integration) — implements all three UI steps (3.1, 3.2, 3.3) plus the backend LLM wiring (gemma4:e2b via Ollama).

Users can now click "✨ Suggest All" to have a local LLM generate descriptive filenames for every screenshot, then accept/reject/edit each suggestion inline on the cards. Settings (provider, model, auto-suggest) are persisted and configurable.

---

## Requirements (from design doc §6 — Phase 3)

| Step | Description | Status |
|------|-------------|--------|
| 3.1 | "✨ AI Suggest" button on unsorted cards (status == "new") | ✅ |
| 3.1 | Suggestion badge showing proposed name (status == "suggested") | ✅ |
| 3.1 | Accept / Reject / Edit buttons for suggestions | ✅ |
| 3.2 | "Suggest All Names" button in header | ✅ |
| 3.2 | Progress indicator during batch processing | ✅ |
| 3.2 | Results appear as cards are processed | ✅ |
| 3.3 | LLM provider selection (Ollama / MLX) | ✅ |
| 3.3 | Model name | ✅ |
| 3.3 | Auto-suggest on scan (on/off) | ✅ |

---

## Changes by File

### `src/ss_dcl/app.py` (+231/-0)

**New endpoints:**

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/api/suggest-names` | Now wired to Ollama (was stub) — calls `gemma4:e2b` with base64-encoded screenshot, parses response, sanitizes to filesystem-safe name, updates memory |
| POST | `/api/accept-suggestion` | Accepts suggestion → renames file on disk, moves thumbnail, updates state.json, updates memory. Handles name conflicts (appends `-2`, `-3`…) |
| POST | `/api/reject-suggestion` | Dismisses suggestion → marks memory status as `"ignored"` |
| GET/PUT | `/api/settings` | Persists LLM config to `~/.ss-dcl/settings.json` |

**Key design decisions:**

- **`_call_ollama_suggest()`** — module-level function (not a method) so tests can monkeypatch it without needing Ollama running
- **Sanitization pipeline** — `lowercase → replace-spaces-with-hyphens → strip-non-alphanumeric → trim → append-.png → truncate-120`
- **LLM prompt** — `"Describe this screenshot in 3-5 words as a filename. Return only the filename, no explanation, no quotes."`
- **Config** — `OLLAMA_BASE_URL` env var (defaults to `http://localhost:11434`), `DEFAULT_LLM_MODEL = "gemma4:e2b"`
- **Settings file** — `~/.ss-dcl/settings.json`, atomic writes (same pattern as state.json)
- **suggested_name** in `/api/screenshots` response — avoids extra fetch for badge display

### `static/app.js` (+313/-?)

**New functions:**

| Function | Purpose |
|----------|---------|
| `suggestSingle(card)` | Sends one fingerprint to `/api/suggest-names` |
| `suggestBatch(fingerprints)` | Processes fingerprints sequentially with progress bar updates |
| `acceptSuggestion(card)` | Calls `/api/accept-suggestion`, renames file, updates card DOM |
| `rejectSuggestion(card)` | Calls `/api/reject-suggestion`, removes badge |
| `editSuggestion(card)` | Opens rename modal pre-filled with suggested name |
| `loadSettings()` | Fetches `/api/settings` on init, stores in `llmSettings` |

**Modified functions:**

- **`init()`** — now calls `loadSettings()` before loading screenshots; triggers auto-suggest if `llmSettings.auto_suggest` is enabled
- **`makeCard()`** — accepts `suggestedName` param; renders suggestion badge when `memoryStatus === "suggested"`
- **`setCardActions()`** — adds "✨ Suggest" button (purple gradient) when `memoryStatus === "new"` and card is in Unsorted column
- **`_makeSuggestionBadge()`** — creates inline badge with ✓ Accept (green), ✕ Reject (orange), ✎ Edit (blue) buttons

**Event handlers:**

- **Suggest All button** — gathers all `dataset.memoryStatus === "new"` fingerprints, calls `suggestBatch()`
- **Settings button (⚙)** — opens settings modal, populates from `llmSettings`
- **Save settings** — PUT to `/api/settings`, updates local state
- **Escape key** — now closes settings modal too

### `templates/index.html` (+38)

New DOM elements:
- `#suggest-all-btn` — header button with purple gradient
- `#settings-btn` — gear icon button in header
- `#suggest-progress` — progress bar container (hidden by default) with fill and text
- `#settings-modal` — modal with provider dropdown, model text input, auto-suggest checkbox, Cancel/Save buttons

### `static/style.css` (+218)

New style sections:
- **`.header-suggest-btn`** — purple gradient (`#af52de → #5856d6`), white text, hover scale
- **`.header-settings-btn`** — minimal gear icon button
- **`.suggestion-badge`** — purple-tinted inline bar below card image, always visible (not hover-only)
- **`.suggestion-badge-btn`** — small colored buttons (green/orange/blue) with hover scale
- **`.suggest-progress`** — fixed header bar with animated gradient fill
- **`.settings-form`** — form fields with consistent styling
- **`.btn-suggest`, `.btn-accept`, `.btn-reject`, `.btn-suggest-edit`** — new action button colors

### `tests/conftest.py` (+1)

Patches `SETTINGS_FILE` in test client fixture (was missing — unpatched, tests could write to real `~/.ss-dcl/settings.json`).

### `tests/test_routes_memory.py` (+383)

20 new tests:

| Test | What it verifies |
|------|-----------------|
| `test_screenshots_includes_suggested_name_when_available` | `suggested_name` field in API response |
| `test_screenshots_suggested_name_null_when_not_suggested` | Field is `null` for un-suggested files |
| `test_suggest_names_with_real_file_and_mock_llm` | Full flow: file on disk → mock LLM → suggestion stored |
| `test_suggest_names_skips_already_processed` | Ignores files with status != "new" |
| `test_suggest_names_handles_llm_returning_none` | Graceful skip when LLM fails |
| `test_suggest_names_unknown_fingerprint_skipped` | Bogus fingerprint doesn't crash |
| `test_accept_suggestion_renames_file` | Renames on disk, updates memory to "renamed" |
| `test_accept_suggestion_handles_name_conflict` | Appends `-2` when target exists |
| `test_accept_suggestion_unknown_fingerprint` | Returns 404 |
| `test_accept_suggestion_no_suggestion_set` | Returns 400 when no suggestion exists |
| `test_accept_suggestion_missing_fingerprint_field` | Returns 400 on missing field |
| `test_reject_suggestion_marks_as_ignored` | Status transitions to "ignored" |
| `test_reject_suggestion_unknown_fingerprint` | Returns 404 |
| `test_reject_suggestion_missing_fingerprint_field` | Returns 400 |
| `test_settings_get_returns_defaults` | Defaults are `ollama` / `gemma4:e2b` / `false` |
| `test_settings_put_and_get_roundtrip` | Save → load returns saved values |
| `test_settings_persists_to_disk` | File written to `SETTINGS_FILE` |
| `test_settings_put_rejects_non_json` | Returns 400 |
| `test_settings_put_ignores_unknown_keys` | Malicious keys filtered |
| `test_call_ollama_suggest_sanitizes_filename` | "Hello World!" → `hello-world.png` |

### `tests/test_frontend.py` (+97)

12 new tests following existing pattern (string checks in served HTML/CSS/JS):
- HTML elements: suggest-all button, settings button, progress bar, settings modal
- JS functions: `suggestBatch`, `acceptSuggestion`, `rejectSuggestion`, `settingsModal`, `_makeSuggestionBadge`
- CSS styles: `suggestion-badge`, `suggest-progress`, `settings-form`

---

## Design Decisions

1. **No Phase 2 abstraction layer.** Rather than building the full `src/ss_dcl/llm/` package with abstract base classes and pluggable providers, the Ollama integration is a single `_call_ollama_suggest()` function in `app.py`. The abstraction can be added later when MLX support is needed — the settings UI already supports provider selection. This keeps the diff focused on working functionality.

2. **Sequential LLM calls with simulated progress.** Batch processing sends fingerprints one at a time (Ollama processes sequentially anyway) and updates the progress bar after each response. No WebSocket/SSE needed — simple, works with the existing Flask test client pattern.

3. **Badge always visible (not hover-only).** Unlike the card action overlay, the suggestion badge is visible at all times so the user can see which cards have been processed. Accept/Reject/Edit are small colored circles (✓ ✕ ✎) to keep the badge compact.

4. **Name conflict resolution on accept.** If the suggested name already exists on disk, the backend appends `-2`, `-3`, etc. This is the same pattern macOS uses for screenshot dedup — familiar and safe.

5. **Prompt engineering kept simple.** The prompt is deliberately minimal: "Describe this screenshot in 3-5 words as a filename." From the empirical evaluation (design doc §11), gemma4:e2b produces excellent output with this prompt — no need for few-shot examples or complex instructions.

6. **`_call_ollama_suggest` is module-level (not a method).** Making it a module-level function allows `monkeypatch.setattr(flask_app, '_call_ollama_suggest', mock)` in tests without needing loose coupling or dependency injection. The function is intentionally simple (no state, no class) for this reason.

---

## Testing

- **204 tests pass** (was 172; +32 new tests)
- **No Ollama required** — all LLM calls mocked via `monkeypatch`
- **Settings isolated** — `SETTINGS_FILE` patched to tmp_path
- **Lint clean** — Ruff + Pyright pass
- **Format clean** — ruff-format passes

---

## How to Test Manually

```bash
# Ensure Ollama is running with gemma4:e2b
ollama pull gemma4:e2b

# Start the app
uv run python -m src.ss_dcl.app

# In the browser:
# 1. Click "✨ Suggest All" to generate names for all new screenshots
# 2. Each card shows a purple badge with the suggested name
# 3. Click ✓ to accept (file is renamed), ✕ to reject, ✎ to edit
# 4. Click ⚙ to change model or enable auto-suggest
```

---

## Future Work (Phase 4)

- Memory pruning / GC (`prune_stale()` already implemented, needs periodic trigger)
- Retry logic for failed Ollama calls
- Parallel LLM calls for batch (ThreadPoolExecutor)
- MLX provider
- FE-011 auto-categorize integration