### PR TITLE
Phase 4: Polish & Production Readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,19 +41,19 @@ tests/test_frontend.py   Frontend integration tests
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | `/` | Serve SPA |
-| GET | `/api/screenshots?sort=<mode>` | List screenshots with fingerprint + memory_status enrichment (sort: name, name_desc, date, date_desc, size, size_desc) |
+| GET | `/api/screenshots?sort=<mode>` | List screenshots with fingerprint, memory_status, suggested_name, suggested_category enrichment (sort: name, name_desc, date, date_desc, size, size_desc) |
 | GET | `/api/image/<filename>` | Serve full-size image (cache: 1h) |
 | GET | `/api/thumb/<filename>` | Serve thumbnail 400x300 max (cache: 24h), falls back to full image |
 | GET | `/api/state` | Get persisted decisions `{decisions: {filename: "keep"|"trash"}}` |
 | PUT | `/api/state` | Save decisions state |
 | POST | `/api/done` | Trash files — body `{filenames: [...]}`. Updates memory with `trashed` status. Returns 207 on partial failure with per-file errors |
-| POST | `/api/rename` | Rename a file — body `{old_name, new_name}`. Updates state, thumbnail, and memory. Returns 409 on conflict |
+| POST | `/api/rename` | Rename a file — body `{old_name, new_name}`. Updates state, thumbnail, memory, and clears suggested_category hint. Returns 409 on conflict |
 | GET | `/api/memory` | Get all persisted memory records `{files: {fingerprint: {status, suggested_name, last_updated}}}` |
-| POST | `/api/suggest-names` | Generate AI filename suggestions via Ollama — body `{fingerprints: [...]}`. Uses `gemma4:e2b` by default |
+| POST | `/api/suggest-names` | Generate AI filename suggestions via Ollama — body `{fingerprints: [...]}`. Returns `{suggestions: {fp: name}, failures: [fp]}`. Uses `gemma4:e2b` by default |
 | POST | `/api/accept-suggestion` | Accept suggestion & rename file — body `{fingerprint}`. Handles name conflicts (appends `-2`) |
 | POST | `/api/reject-suggestion` | Dismiss suggestion — body `{fingerprint}`. Marks memory status as `"ignored"` |
-| GET | `/api/settings` | Get LLM config `{llm_provider, llm_model, auto_suggest}` |
-| PUT | `/api/settings` | Save LLM config — body `{llm_provider?, llm_model?, auto_suggest?}` |
+| GET | `/api/settings` | Get config `{llm_provider, llm_model, auto_suggest, prune_max_age_days}` |
+| PUT | `/api/settings` | Save config — body `{llm_provider?, llm_model?, auto_suggest?, prune_max_age_days?}` |
 
 All filename-accepting routes validate against path traversal: bare name check (`filename == Path(filename).name`) + resolved path must be within `~/Desktop`.
 
@@ -69,7 +69,9 @@ All in `static/app.js`:
 - **Undo**: `performUndo()` pops from stack, reverses the move
 - **Lightbox**: Double-click or Preview button → full-size overlay. Escape or backdrop click closes
 - **Confirm modal**: Done button → modal with trash count → POST `/api/done`
-- **Rename modal**: Rename button → modal with text input → POST `/api/rename`. Updates card dataset filename, state, and thumbnail
+- **Rename modal**: Rename button → modal with text input → POST `/api/rename`. Updates card dataset filename, state, thumbnail, and clears category hint
+- **Theme toggle**: ☀/☾ button cycles auto/dark/light; persisted in localStorage; follows system preference in auto mode
+- **Category hints**: Colored left border (green=keep, red=trash) when auto-categorization has sufficient signal; cleared on accept/reject/rename
 
 ## Runtime Paths
 
@@ -94,7 +96,7 @@ All in `static/app.js`:
 - Fixture: `client(tmp_path, monkeypatch)` — temp dir as fake Desktop, patches `DESKTOP`, `THUMB_DIR`, `STATE_FILE`
 - `send2trash` always mocked to avoid actually trashing files
 - Helper `_make_png()` creates valid minimal PNGs in-memory
-- ~210 tests across focused test files covering all routes, sorting, path traversal, state round-trip, partial failures, rename, port flexibility, edge cases, LLM suggest/accept/reject flows
+- ~244 tests across focused test files covering all routes, sorting, path traversal, state round-trip, partial failures, rename, port flexibility, edge cases, LLM suggest/accept/reject flows, pruning, dark mode, auto-categorization, LLM retry
 
 ## Tooling Config
 

--- a/docs/design-phase4-polish.md
+++ b/docs/design-phase4-polish.md
@@ -1,0 +1,736 @@
+# Phase 4 — Polish & Production Readiness
+
+**Branch:** `phase4`
+**Base:** `add-llm`
+**Date:** 2026-06-24
+**Status:** planning
+
+---
+
+## 1. Overview
+
+Phase 4 hardens the application for daily use. Four workstreams in priority order:
+
+| # | Workstream | Effort | Risk |
+|---|-----------|--------|------|
+| **4A** | Memory pruning / GC | S (~30 lines) | Low |
+| **4B** | Dark mode | M (~150 lines) | Low |
+| **4C** | Auto-categorization (FE-011) | L (~200 lines) | Medium |
+| **4D** | LLM retry / error recovery | S (~40 lines) | Low |
+
+Each produces a working, testable, deployable state. None depends on the others.
+
+---
+
+## 2. Workstream 4A — Memory Pruning / GC
+
+### 2.1 Problem
+
+`memory.json` grows unbounded. Every screenshot ever seen by the app gets a permanent record — including files long since trashed, renamed, or deleted. Over months of use this file accumulates hundreds of orphaned entries. There's no cleanup mechanism.
+
+`MemoryStore.prune_stale()` already exists and works correctly (tested in `test_memory.py`), but nothing calls it.
+
+### 2.2 Design
+
+**Trigger:** On every `GET /api/screenshots` scan, after building the file list, call `prune_stale()` with the set of active fingerprints. This keeps memory.json proportional to the number of screenshots currently on Desktop (+ a 90-day grace window for recently trashed/renamed files).
+
+**Configurable:** Max age is configurable via settings. Default 90 days.
+
+**Logging:** Log how many records were pruned so the user can observe GC activity in the console (not in the UI — it's invisible maintenance).
+
+### 2.3 Implementation Plan
+
+#### 2.3.1 Backend — `app.py`
+
+```python
+# In get_screenshots(), after the scan loop completes and before the sort/return:
+
+# ── Memory pruning ──────────────────────────────────────────
+# After every scan, prune orphaned entries older than the
+# configured max_age_days (default 90).  Active fingerprints
+# are those belonging to files still on disk right now.
+if any_new or True:  # prune on every scan, not just when new files appear
+    settings = _load_settings()
+    max_age = settings.get("prune_max_age_days", 90)
+    active_fps = {f["fingerprint"] for f in files}
+    pruned = memory.prune_stale(active_fps, max_age_days=max_age)
+    if pruned > 0:
+        logger.info("Pruned %d stale memory entries (max age: %d days)", pruned, max_age)
+        memory.save()
+```
+
+**Note:** `prune_stale()` uses `rec.last_updated` to determine age. This is updated on every mutation (`update_suggestion`, `accept_suggestion`, `reject_suggestion`, `record_rename`, `mark_trashed`). Entries that were created but never touched (status stays `"new"` and file was deleted) will use `first_seen` via the `last_updated` fallback (which equals `first_seen` at creation time). This is correct behavior.
+
+#### 2.3.2 Settings extension
+
+Add `prune_max_age_days` to the settings file and API. Default `90`, accept any positive integer. The settings modal doesn't need a UI for this (it's an advanced config — power users can edit `settings.json` directly, or we add it to the settings modal as an optional field).
+
+```python
+# In api_save_settings():
+type_checks = {
+    "llm_provider": str,
+    "llm_model": str,
+    "auto_suggest": bool,
+    "prune_max_age_days": int,          # NEW
+}
+for key in ("llm_provider", "llm_model", "auto_suggest", "prune_max_age_days"):
+    ...
+
+# In api_get_settings():
+return jsonify({
+    "llm_provider": s.get("llm_provider", "ollama"),
+    "llm_model": s.get("llm_model", DEFAULT_LLM_MODEL),
+    "auto_suggest": s.get("auto_suggest", False),
+    "prune_max_age_days": s.get("prune_max_age_days", 90),   # NEW
+})
+```
+
+#### 2.3.3 Settings Modal — add prune age field
+
+```html
+<div class="settings-field">
+  <label for="settings-prune-age">Prune memory after (days)</label>
+  <input id="settings-prune-age" type="number" min="1" max="730"
+         class="rename-input" />
+</div>
+```
+
+JS: wire `#settings-prune-age` to `llmSettings.prune_max_age_days`.
+
+#### 2.3.4 Tests
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_scan_triggers_prune_stale` | After scanning, orphaned entries beyond max age are removed from memory.json |
+| `test_prune_respects_settings_age` | Changing `prune_max_age_days` in settings affects what gets pruned |
+| `test_prune_keeps_active_entries` | Files still on disk are never pruned regardless of age |
+| `test_prune_keeps_recent_inactive` | Files trashed 5 days ago are kept when max_age=90 |
+| `test_settings_prune_age_roundtrip` | Save → load preserves prune_max_age_days |
+| `test_settings_prune_age_type_validation` | Non-integer values rejected |
+
+### 2.4 Edge Cases
+
+- **Empty Desktop** → `active_fps` is empty → all entries older than max_age are pruned. Correct — no files means no need to remember anything old.
+- **Very first scan (memory.json doesn't exist)** → `prune_stale` with empty store returns 0. Harmless.
+- **User sets `prune_max_age_days=1`** → trashed files disappear from memory after 1 day. If the file is restored from Trash after 2 days, it appears as "new" and gets re-analyzed. Acceptable — the user explicitly chose aggressive pruning.
+- **User sets `prune_max_age_days=730`** → effectively disables pruning. Memory grows unbounded. Acceptable — power user choice.
+
+---
+
+## 3. Workstream 4B — Dark Mode
+
+### 3.1 Problem
+
+The app is bright white (#fff, #f5f5f7). Using it at night is harsh. macOS supports system-wide dark mode preferences; the app should respect them.
+
+### 3.2 Design
+
+**Approach:** CSS custom properties (variables) with a `[data-theme="dark"]` selector on `<html>`. A small JS module reads `prefers-color-scheme` and sets the attribute on load, then listens for changes. A manual toggle (sun/moon icon in header) overrides the system preference and persists the choice to `localStorage`.
+
+**Scope:** Full app — not just Phase 3 elements. The CSS is only ~450 lines; a full pass is manageable and avoids the jarring experience of partially-themed UI.
+
+**No backend changes.** This is purely CSS + a few lines of JS.
+
+### 3.3 Implementation Plan
+
+#### 3.3.1 CSS Architecture
+
+Define all colors as custom properties on `:root` (light) and `[data-theme="dark"]` (dark), then reference them everywhere:
+
+```css
+/* ── Theme variables ─────────────────────────────────────── */
+
+:root {
+  --bg-body:       #f5f5f7;
+  --bg-header:     #fff;
+  --bg-column:     #fafafa;
+  --bg-unsorted:   #f5f5f7;
+  --bg-card:       #fff;
+  --bg-modal:      #fff;
+  --bg-modal-overlay: rgba(0, 0, 0, 0.45);
+  --bg-progress:   #f0e6ff;
+  --bg-badge:      #f3e8ff;
+  --bg-btn-cancel: #f0f0f0;
+  --bg-btn-cancel-hover: #e4e4e4;
+  --bg-settings-btn: #f0f0f0;
+  --bg-settings-btn-hover: #e0e0e0;
+  --bg-cancel-suggest: #fff;
+  --bg-cancel-suggest-hover: #f0e6ff;
+
+  --text-primary:  #1a1a1a;
+  --text-secondary: #666;
+  --text-muted:    #888;
+  --text-header:   inherit;
+  --text-badge:    #6b21a8;
+  --text-progress: #6b21a8;
+
+  --border-col:    #e5e5e5;
+  --border-header: #e0e0e0;
+  --border-badge:  #e0d0f0;
+  --border-progress: #e0d0f0;
+
+  --shadow-card:   0 1px 6px rgba(0,0,0,.08);
+  --shadow-card-hover: 0 3px 12px rgba(0,0,0,.14);
+  --shadow-header: 0 1px 4px rgba(0,0,0,.06);
+
+  --count-bg:      #eee;
+  --count-text:    #666;
+  --count-trash-bg: #fff0f0;
+  --count-trash-text: #ff3b30;
+  --count-keep-bg: #f0fff4;
+  --count-keep-text: #34c759;
+
+  --column-title:  #888;
+  --column-trash-title: #ff3b30;
+  --column-keep-title:  #34c759;
+
+  --lightbox-bar-bg: rgba(0, 0, 0, 0.55);
+  --lightbox-filename: rgba(255, 255, 255, 0.9);
+  --lightbox-filename-hover: rgba(255, 255, 255, 0.15);
+  --lightbox-rename-bg: rgba(255, 255, 255, 0.2);
+  --lightbox-close-bg: rgba(255, 255, 255, 0.15);
+  --lightbox-close-hover: rgba(255, 255, 255, 0.3);
+  --lightbox-backdrop: rgba(0, 0, 0, 0.8);
+}
+
+[data-theme="dark"] {
+  --bg-body:       #1c1c1e;
+  --bg-header:     #2c2c2e;
+  --bg-column:     #242426;
+  --bg-unsorted:   #1c1c1e;
+  --bg-card:       #2c2c2e;
+  --bg-modal:      #2c2c2e;
+  --bg-modal-overlay: rgba(0, 0, 0, 0.7);
+  --bg-progress:   #2d1f3a;
+  --bg-badge:      #2d1f3a;
+  --bg-btn-cancel: #3a3a3c;
+  --bg-btn-cancel-hover: #48484a;
+  --bg-settings-btn: #3a3a3c;
+  --bg-settings-btn-hover: #48484a;
+  --bg-cancel-suggest: #3a3a3c;
+  --bg-cancel-suggest-hover: #2d1f3a;
+
+  --text-primary:  #f5f5f7;
+  --text-secondary: #aeaeb2;
+  --text-muted:    #8e8e93;
+  --text-header:   #f5f5f7;
+  --text-badge:    #d4a0f0;
+  --text-progress: #d4a0f0;
+
+  --border-col:    #38383a;
+  --border-header: #38383a;
+  --border-badge:  #4a305a;
+  --border-progress: #4a305a;
+
+  --shadow-card:   0 1px 6px rgba(0,0,0,.3);
+  --shadow-card-hover: 0 3px 12px rgba(0,0,0,.5);
+  --shadow-header: 0 1px 4px rgba(0,0,0,.3);
+
+  --count-bg:      #3a3a3c;
+  --count-text:    #aeaeb2;
+  --count-trash-bg: #3d1c1c;
+  --count-trash-text: #ff6961;
+  --count-keep-bg: #1c3d24;
+  --count-keep-text: #32d74b;
+
+  --column-title:  #8e8e93;
+  --column-trash-title: #ff6961;
+  --column-keep-title:  #32d74b;
+
+  --lightbox-bar-bg: rgba(44, 44, 46, 0.85);
+  --lightbox-filename: rgba(245, 245, 247, 0.9);
+  --lightbox-filename-hover: rgba(245, 245, 247, 0.15);
+  --lightbox-rename-bg: rgba(245, 245, 247, 0.15);
+  --lightbox-close-bg: rgba(245, 245, 247, 0.15);
+  --lightbox-close-hover: rgba(245, 245, 247, 0.3);
+  --lightbox-backdrop: rgba(0, 0, 0, 0.9);
+}
+```
+
+Then replace every hardcoded color in `style.css` with `var(--xxx)`. For example:
+
+```css
+/* Before */
+body { background: #f5f5f7; color: #1a1a1a; }
+
+/* After */
+body { background: var(--bg-body); color: var(--text-primary); }
+```
+
+All `#xxxxxx` colors in the stylesheet get replaced with their variable counterpart. This is a mechanical find-replace across ~50 declarations.
+
+#### 3.3.2 Theme toggle — HTML
+
+Add a button in the header, between the settings gear and the sort select:
+
+```html
+<button id="theme-toggle" class="header-theme-btn" aria-label="Toggle dark mode">
+  <span class="theme-icon-light">☀</span>
+  <span class="theme-icon-dark">☾</span>
+</button>
+```
+
+```css
+.header-theme-btn {
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: var(--bg-settings-btn);
+  color: var(--text-primary);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.header-theme-btn:hover { background: var(--bg-settings-btn-hover); }
+
+/* Show/hide icons based on theme */
+[data-theme="dark"] .theme-icon-light { display: none; }
+[data-theme="dark"] .theme-icon-dark  { display: inline; }
+:root .theme-icon-dark  { display: none; }
+:root .theme-icon-light { display: inline; }
+```
+
+#### 3.3.3 Theme JS module
+
+```javascript
+// ── Theme management ─────────────────────────────────────────
+const THEME_KEY = "ss-dcl-theme";
+
+function applyTheme(mode) {
+  if (mode === "dark") {
+    document.documentElement.setAttribute("data-theme", "dark");
+  } else if (mode === "light") {
+    document.documentElement.removeAttribute("data-theme");
+  } else {
+    // "auto" — follow system
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    document.documentElement.toggleAttribute("data-theme", prefersDark);
+  }
+}
+
+function getSavedTheme() {
+  try { return localStorage.getItem(THEME_KEY) || "auto"; } catch (_) { return "auto"; }
+}
+
+function saveTheme(mode) {
+  try { localStorage.setItem(THEME_KEY, mode); } catch (_) {}
+}
+
+function cycleTheme() {
+  const current = getSavedTheme();
+  const next = { auto: "dark", dark: "light", light: "auto" }[current] || "auto";
+  saveTheme(next);
+  applyTheme(next);
+}
+
+// On load
+applyTheme(getSavedTheme());
+
+// Listen for system changes (only matters when mode is "auto")
+window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
+  if (getSavedTheme() === "auto") applyTheme("auto");
+});
+
+// Wire the toggle button
+document.getElementById("theme-toggle").addEventListener("click", cycleTheme);
+```
+
+**Behavior:**
+- Default: `"auto"` — follows system preference, no `localStorage` entry
+- Click once: `"dark"` — forces dark, saved to `localStorage`
+- Click again: `"light"` — forces light, saved to `localStorage`
+- Click again: `"auto"` — back to system, saved to `localStorage`
+- System preference change: only takes effect when mode is `"auto"`
+
+#### 3.3.4 Tests
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_index_has_theme_toggle` | `#theme-toggle` button exists in HTML |
+| `test_app_js_has_theme_cycle` | `function cycleTheme` or `THEME_KEY` appears in JS |
+| `test_css_has_dark_variables` | `[data-theme="dark"]` block exists in CSS with `--bg-body` |
+| `test_css_has_light_variables` | `:root` block exists with CSS custom properties |
+
+### 3.4 Edge Cases
+
+- **`localStorage` unavailable** (private browsing, old browser) → `try/catch` around all `localStorage` calls. Falls back to `"auto"` in memory, which follows system preference. The toggle button still works for the session.
+- **System preference changes mid-session** → `matchMedia` listener re-applies when mode is `"auto"`. When mode is `"dark"` or `"light"` (manual override), system changes are ignored.
+- **Browser doesn't support `prefers-color-scheme`** → `matchMedia(...).matches` returns `false` → light theme. Graceful degradation.
+- **CSS variable not defined** → Browser uses initial/inherited value. Fallback colors are the light theme (defined in `:root`), so missing dark variables just show light colors in dark mode. Not ideal but not broken.
+
+---
+
+## 4. Workstream 4C — Auto-Categorization (FE-011)
+
+### 4.1 Problem
+
+Users manually sort every screenshot into Keep/Trash. Many screenshots follow patterns (e.g., "all code editor screenshots → Keep, all meme screenshots → Trash"). The app could learn these patterns and suggest a column, reducing manual work.
+
+### 4.2 Design
+
+**Approach: Heuristic-based, not ML.** A full ML pipeline (training, feature extraction, model serving) is overkill for a local single-user tool. Instead, use lightweight heuristics that improve with use:
+
+1. **Filename patterns** — if the user always trashes files matching `Screenshot * at *.?? PM.png` (evening screenshots) but keeps `Screenshot * at *.?? AM.png` (morning work), learn that.
+2. **Content-based via LLM** — we already have LLM integration. After the LLM generates a name like `"customer-onboarding-thread.png"`, we can ask a second, tiny question: *"Does this screenshot look like work or personal?"* and use the answer as a categorization hint.
+3. **User history** — for any fingerprint that's been categorized before (Keep/Trash), reuse the decision if the same file reappears.
+
+Actually, **let me simplify.** The most practical auto-categorization for this app is:
+
+**Heuristic A: Content keywords from LLM suggestion.** After the LLM suggests a name, extract keywords and check against user's historical patterns. If the suggested name contains words from previously-kept files → suggest Keep. If from previously-trashed → suggest Trash.
+
+**Heuristic B: Time-of-day.** Screenshots taken during work hours (9-5) might be work-related → suggest Keep. Evening/weekend → unsure.
+
+**Heuristic C: App source (future).** If we add OCR or window-title extraction, we could know which app produced the screenshot. Code editor → Keep, social media → Trash. This requires macOS accessibility APIs and is out of scope for now.
+
+**Recommendation: Start with Heuristic A only** — it's zero additional work since we already have LLM suggestions. The `memory.meta` field stores the keywords.
+
+### 4.3 Revised Design (Heuristic A Only)
+
+Flow:
+
+```
+1. LLM generates suggested name: "customer-onboarding-discussion.png"
+2. Extract keywords: ["customer", "onboarding", "discussion"]
+3. Check user's history:
+   - Files user KEPT that share these keywords → keep_score += 1 per match
+   - Files user TRASHED that share these keywords → trash_score += 1 per match
+4. If keep_score > trash_score → suggest "Keep" (show green hint on card)
+   If trash_score > keep_score → suggest "Trash" (show red hint on card)
+   If equal or no history → neutral (no hint)
+5. Store keywords in memory.meta for future reference
+```
+
+**Keyword extraction from LLM output:**
+
+```python
+def extract_keywords(suggested_name: str) -> list[str]:
+    """Extract stemmed keywords from a kebab-case filename."""
+    # "customer-onboarding-discussion.png" → ["customer", "onboarding", "discussion"]
+    stem = Path(suggested_name).stem
+    return [w.lower() for w in stem.split("-") if len(w) > 2]
+```
+
+**Categorization logic:**
+
+```python
+def suggest_category(
+    keywords: list[str],
+    memory: MemoryStore,
+) -> Optional[str]:
+    """Return 'keep', 'trash', or None based on historical patterns."""
+    keep_score = 0
+    trash_score = 0
+
+    for rec in memory.all_records():
+        if rec.status in ("renamed", "trashed"):
+            rec_keywords = rec.meta.get("keywords", [])
+            overlap = set(keywords) & set(rec_keywords)
+            if rec.status == "renamed":   # user accepted → kept
+                keep_score += len(overlap)
+            elif rec.status == "trashed":
+                trash_score += len(overlap)
+
+    if keep_score > trash_score:
+        return "keep"
+    elif trash_score > keep_score:
+        return "trash"
+    return None  # neutral
+```
+
+### 4.4 Integration Points
+
+#### 4.4.1 Backend — `app.py`
+
+After `api_suggest_names` updates the suggestion, run categorization:
+
+```python
+# In api_suggest_names, after memory.update_suggestion():
+keywords = extract_keywords(suggested)
+category = suggest_category(keywords, memory)
+if category:
+    rec = memory.lookup(fp)
+    rec.meta["keywords"] = keywords
+    rec.meta["suggested_category"] = category
+```
+
+Add `suggested_category` to `GET /api/screenshots` response:
+
+```python
+files.append({
+    ...
+    "suggested_category": existing.meta.get("suggested_category") if existing else None,
+})
+```
+
+#### 4.4.2 Frontend — `app.js`
+
+When a card has `suggested_category === "keep"`, show a subtle green left-border or a small "✨ Keep?" badge below the suggestion badge. When `"trash"`, red. When `null`, nothing.
+
+```javascript
+// In makeCard(), after building the card:
+if (suggestedCategory === "keep") {
+  card.style.borderLeft = "3px solid #34c759";
+} else if (suggestedCategory === "trash") {
+  card.style.borderLeft = "3px solid #ff3b30";
+}
+```
+
+Or, more consistently: add a small colored dot in the suggestion badge area.
+
+```javascript
+// In _makeSuggestionBadge(), after the name span:
+if (card.dataset.suggestedCategory === "keep") {
+  const hint = document.createElement("span");
+  hint.className = "suggestion-category-hint keep";
+  hint.textContent = "✨ Keep?";
+  badge.appendChild(hint);
+}
+```
+
+### 4.5 Tests
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_extract_keywords_from_suggested_name` | `"foo-bar-baz.png"` → `["foo", "bar", "baz"]` |
+| `test_extract_keywords_filters_short_words` | `"a-b-cat.png"` → `["cat"]` |
+| `test_suggest_category_no_history_returns_none` | Empty memory → `None` |
+| `test_suggest_category_keep_when_keywords_match_kept` | Previously kept files with matching keywords → `"keep"` |
+| `test_suggest_category_trash_when_keywords_match_trashed` | Previously trashed files with matching keywords → `"trash"` |
+| `test_suggest_category_tie_returns_none` | Equal keep/trash scores → `None` |
+| `test_suggest_names_stores_keywords_in_meta` | After LLM suggest, `rec.meta.keywords` is populated |
+| `test_screenshots_includes_suggested_category` | Response includes `suggested_category` field |
+| `test_frontend_card_shows_category_hint` | JS has code for category-based visual hints |
+
+### 4.6 Edge Cases
+
+- **No LLM suggestions yet** → No keywords, no categorization. Neutral. Works.
+- **All history is trashed (user is aggressive)** → Everything gets categorized as "trash". The user might want to reset. Future feature: "reset learning data" button.
+- **Keywords overlap with both keep and trash** → Score-based tie-breaking. Higher overlap wins.
+- **Single-word suggestions** (e.g., `"screenshot.png"`) → Only one keyword, weak signal. Most won't match history → neutral. Acceptable.
+- **memory.meta grows** → Each record stores a `keywords` list. For 500 files with ~3 keywords each, that's ~500 × 3 × 10 bytes ≈ 15 KB. Negligible.
+- **Privacy** → Keywords are stored locally in `memory.json`. They're just word fragments from filenames. No user data leaves the machine.
+
+---
+
+## 5. Workstream 4D — LLM Retry / Error Recovery
+
+### 5.1 Problem
+
+`_call_ollama_suggest` has a single 30s timeout with no retry. Ollama can be slow to load the model on first request (cold start: 10-30s), or the model might be temporarily busy with another request. One failure and the file is skipped forever (status stays `"new"` but `api_suggest_names` won't retry because it only processes `"new"` files — but it doesn't change status on failure, so it *will* retry on the next scan... unless the user doesn't trigger another suggest).
+
+Actually, looking at the code again: `api_suggest_names` skips files whose status is not `"new"`. On LLM failure, the status stays `"new"` — so the file *will* be retried next time. The real issue is: **the user gets a silent failure with no feedback during the current batch**, and has to manually re-trigger "Suggest All".
+
+### 5.2 Design
+
+**Retry logic:** Retry failed Ollama calls up to 2 times with exponential backoff (1s, 3s). Only mark as permanently failed after 3 attempts.
+
+**Timeout:** Increase initial timeout to 60s (model cold-start can exceed 30s on first request). Subsequent requests in the same batch reuse the loaded model and are faster.
+
+**Status for failed files:** Introduce a transient status `"retry"` in the frontend (not persisted — it's session-only) so the user sees "3 files failed — try again?".
+
+Actually, simpler approach: **Keep status as `"new"` on failure** (already the case), but **track failures in the batch response** and show them in the UI. The progress bar already has `firstError` tracking. Enhance it:
+
+```python
+# In api_suggest_names, return failures alongside suggestions:
+return jsonify({
+    "suggestions": {...},
+    "failures": ["fp1", "fp2"],   # fingerprints that failed
+    "error": None,                 # or a global error message
+})
+```
+
+And in the JS:
+
+```javascript
+if (data.failures && data.failures.length > 0) {
+  // Show "3 files couldn't be processed — try again?"
+  statusMsg.textContent = `${data.failures.length} files couldn't be processed. Try again?`;
+}
+```
+
+### 5.3 Implementation Plan
+
+#### 5.3.1 Backend — retry in `_call_ollama_suggest`
+
+```python
+def _call_ollama_suggest(
+    image_path: Path,
+    model: str,
+    extension: str = ".png",
+    max_retries: int = 2,
+) -> Optional[str]:
+    ...
+    for attempt in range(max_retries + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                result = json.loads(resp.read())
+                raw = result.get("message", {}).get("content", "").strip()
+                break  # success → exit retry loop
+        except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+            if attempt < max_retries:
+                wait = (2 ** attempt)  # 1s, 2s
+                logger.warning(
+                    "Ollama attempt %d/%d failed for %s, retrying in %ds: %s",
+                    attempt + 1, max_retries + 1, image_path.name, wait, exc,
+                )
+                time.sleep(wait)
+            else:
+                logger.warning(
+                    "Ollama suggest failed after %d attempts for %s: %s",
+                    max_retries + 1, image_path.name, exc,
+                )
+                return None
+    ...
+```
+
+#### 5.3.2 Backend — return failures
+
+```python
+# In api_suggest_names:
+failures: list[str] = []
+
+for fp in fingerprints:
+    ...
+    suggested = _call_ollama_suggest(file_path, model, rec.extension)
+    if suggested:
+        ...
+    else:
+        failures.append(fp)
+
+return jsonify({
+    "suggestions": suggestions,
+    "failures": failures,
+})
+```
+
+#### 5.3.3 Frontend — show failure count
+
+In `suggestBatch`, after the batch completes, check `failures`:
+
+```javascript
+// After all chunks processed:
+if (failures.length > 0) {
+    statusMsg.textContent =
+        `${failures.length} file${failures.length > 1 ? "s" : ""} couldn't be processed. Try again?`;
+}
+```
+
+#### 5.3.4 Tests
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_suggest_names_returns_failures_list` | Failures appear in response when LLM returns None |
+| `test_suggest_names_empty_failures_on_success` | `failures: []` when all succeed |
+| `test_call_ollama_suggest_retries_on_failure` | Retries up to max_retries times before giving up |
+| `test_call_ollama_suggest_succeeds_on_retry` | Second attempt succeeds → returns suggestion |
+| `test_frontend_shows_failure_count` | JS code references `failures.length` or similar |
+
+### 5.4 Edge Cases
+
+- **All files fail** → progress bar shows "0 processed", status message shows failure count.
+- **Partial failure** → some get badges, some don't. Status message shows count. User can re-trigger "Suggest All" (failed files are still `"new"`).
+- **Ollama crashes mid-batch** → Each file is tried independently. First failure triggers retries. Subsequent files also retry. The batch continues with remaining files.
+- **Network timeout vs model-not-found** → `URLError` covers both. The retry loop is the same. If model isn't pulled at all, all retries fail quickly → all files appear in `failures`.
+
+---
+
+## 6. File Change Summary
+
+### 4A — Memory Pruning
+
+| File | Action | Lines (est.) |
+|------|--------|-------------|
+| `src/ss_dcl/app.py` | Modify `get_screenshots()` + settings endpoints | +15, ~3 changed |
+| `static/app.js` | Add prune age to settings modal | +5 |
+| `templates/index.html` | Add prune age input to settings | +5 |
+| `tests/test_routes_memory.py` | 5 new pruning tests | +80 |
+
+### 4B — Dark Mode
+
+| File | Action | Lines (est.) |
+|------|--------|-------------|
+| `static/style.css` | Replace colors with `var(--xxx)`, add `:root` + `[data-theme]` blocks | ~+120, ~50 changed |
+| `static/app.js` | Theme management module | +30 |
+| `templates/index.html` | Theme toggle button | +5 |
+| `tests/test_frontend.py` | 3 new theme tests | +30 |
+
+### 4C — Auto-Categorization
+
+| File | Action | Lines (est.) |
+|------|--------|-------------|
+| `src/ss_dcl/app.py` | `extract_keywords()`, `suggest_category()`, wire into suggest-names | +50 |
+| `src/ss_dcl/memory.py` | No changes (uses existing `meta` field) | 0 |
+| `static/app.js` | Category hint in badge, `suggestedCategory` dataset | +20 |
+| `tests/test_routes_memory.py` | 6 new categorization tests | +100 |
+
+### 4D — LLM Retry
+
+| File | Action | Lines (est.) |
+|------|--------|-------------|
+| `src/ss_dcl/app.py` | Retry loop in `_call_ollama_suggest`, failures in response | +25, ~5 changed |
+| `static/app.js` | Show failure count in status | +10 |
+| `tests/test_routes_memory.py` | 4 new retry tests | +70 |
+
+### Totals
+
+| Workstream | Est. Lines |
+|-----------|-----------|
+| 4A — Pruning | ~105 |
+| 4B — Dark mode | ~235 |
+| 4C — Auto-categorization | ~170 |
+| 4D — LLM retry | ~110 |
+| **Total** | **~620** |
+
+---
+
+## 7. Validation Against Current Codebase
+
+### Checkpoint 1: Does this break existing tests?
+- **4A**: `get_screenshots` gains a `prune_stale` call. Existing tests use temp dirs with freshly-created files → no stale entries to prune → `prune_stale` returns 0. No test breakage.
+- **4B**: CSS variable changes are purely visual. Existing frontend tests check for IDs and class names in source, not color values. No test breakage.
+- **4C**: `suggested_category` added to API response (additive field). Existing tests don't assert on its absence. `meta.keywords` added to existing records. No test breakage.
+- **4D**: `_call_ollama_suggest` signature unchanged (added keyword-only `max_retries`). Existing mocks ignore extra kwargs. Response adds `failures` field — existing tests for unknown fingerprints return `{"suggestions": {}, "failures": []}`. The empty dict test `{"suggestions": {}}` will need updating. **One test needs adjustment.**
+
+### Checkpoint 2: Does this fit the project philosophy?
+- ✅ No build step
+- ✅ No new runtime dependencies
+- ✅ Single-user, localhost-only
+- ✅ JSON file storage (settings.json extended)
+- ✅ Atomic writes where needed
+- ✅ Vanilla JS, no frameworks
+- ✅ Zero additional I/O (pruning uses in-memory data)
+
+### Checkpoint 3: Is this extensible?
+- CSS variables make future theming trivial (add `[data-theme="high-contrast"]`)
+- `memory.meta` dict already supports arbitrary data — categorization is just the first use
+- Retry logic is parameterized (`max_retries`) — easy to make configurable
+- Pruning age is already in settings — can add UI for it later
+
+---
+
+## 8. Dependency Graph
+
+```
+4A (pruning) ── independent ── can be implemented first
+    │
+4B (dark mode) ── independent ── purely CSS/JS, no backend
+    │
+4C (auto-categorization) ── depends on Phase 3 (LLM suggestions exist)
+    │
+4D (retry) ── depends on Phase 3 (_call_ollama_suggest exists)
+```
+
+All four can be done in any order. Recommended order: 4A → 4B → 4D → 4C (simplest first, builds confidence).
+
+---
+
+## 9. Risk Analysis
+
+| Risk | Mitigation |
+|------|-----------|
+| Pruning too aggressive | Default 90 days is conservative. Configurable. Log every prune. |
+| Dark mode colors look bad | Use macOS system colors as reference. Test manually on real machine. |
+| Auto-categorization suggests wrong column | It's a *suggestion* (subtle hint), not an automatic move. User still has final say. |
+| Retry loop hangs on persistent failure | Max 3 attempts × 60s timeout = 3 min max per file. Acceptable for local tool. |
+| CSS variable refactor introduces visual regressions | Mechanical find-replace. Visual diff by running the app before/after. |
+| `failures` field changes API contract | Old frontend ignores unknown fields. New frontend checks for it. Backward compatible. |

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -151,7 +151,16 @@ def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
             active_fps.add(rec.fingerprint)
             any_new = True
         suggested_name = existing.suggested_name if existing else None
-        suggested_category = existing.meta.get("suggested_category") if existing else None
+        # Recompute suggested_category from keywords + current decisions
+        # (refreshes hints as user history accumulates)
+        if existing and existing.meta.get("keywords"):
+            suggested_category = suggest_category(
+                existing.meta["keywords"], memory, _read_decisions()
+            )
+            if suggested_category != existing.meta.get("suggested_category"):
+                existing.meta["suggested_category"] = suggested_category
+        else:
+            suggested_category = existing.meta.get("suggested_category") if existing else None
         files.append(
             {
                 "name": name,

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -94,8 +94,23 @@ def _get_memory() -> MemoryStore:
 
 def _reset_memory() -> None:
     global _memory_store
+    global _prune_max_age_cache
     with _memory_lock:
         _memory_store = None
+    _prune_max_age_cache = None
+
+
+# ── Settings cache (prune age) ──────────────────────────────────────────────
+_prune_max_age_cache: Optional[int] = None
+
+
+def _prune_max_age() -> int:
+    global _prune_max_age_cache
+    if _prune_max_age_cache is None:
+        _prune_max_age_cache = _load_settings().get("prune_max_age_days", 90)
+    # Global could be None in theory, but we just ensured it's set above
+    age: int = _prune_max_age_cache  # type: ignore[assignment]
+    return age
 
 
 _dirs_initialized = False
@@ -114,6 +129,7 @@ def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
     memory = _get_memory()
     files: list[dict[str, Any]] = []
     any_new = False
+    active_fps: set[str] = set()
     for p in DESKTOP.glob("Screenshot*.*"):
         if not p.is_file() or (p.suffix.lower() not in SUPPORTED_IMAGE_EXTENSION):
             continue
@@ -128,11 +144,14 @@ def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
             existing = memory.lookup_by_name(name)
         if existing is not None:
             memory_status = existing.status
+            active_fps.add(existing.fingerprint)
         else:
-            memory.record_file(name, size)
+            rec = memory.record_file(name, size)
             memory_status = "new"
+            active_fps.add(rec.fingerprint)
             any_new = True
         suggested_name = existing.suggested_name if existing else None
+        suggested_category = existing.meta.get("suggested_category") if existing else None
         files.append(
             {
                 "name": name,
@@ -141,10 +160,18 @@ def get_screenshots(sort: str = "name") -> list[dict[str, Any]]:
                 "fingerprint": fp,
                 "memory_status": memory_status,
                 "suggested_name": suggested_name,
+                "suggested_category": suggested_category,
             }
         )
     if any_new:
         memory.save()
+
+    # ── Memory pruning (4A) ──────────────────────────────────────────
+    pruned = memory.prune_stale(active_fps, max_age_days=_prune_max_age())
+    if pruned > 0:
+        logger.info("Pruned %d stale memory entries (max age: %d days)", pruned, _prune_max_age())
+        memory.save()
+
     key, reverse = SORT_OPTIONS.get(sort, ("name", False))
     return sorted(files, key=lambda f: f[key], reverse=reverse)
 
@@ -361,11 +388,7 @@ def api_rename():
 
 @app.route("/api/memory")
 def api_memory():
-    """Return memory status for all recorded files.
-
-    TODO(phase-1b): periodically call memory.prune_stale(active_fingerprints)
-    to prevent unbounded growth of orphaned entries from long-trashed files.
-    """
+    """Return memory status for all recorded files."""
     memory = _get_memory()
     result: dict[str, dict[str, Any]] = {}
     for rec in memory.all_records():
@@ -386,7 +409,11 @@ def _call_ollama_suggest(image_path: Path, model: str, extension: str = ".png") 
     *extension* is appended to the sanitized name and should include
     the leading dot (e.g. ``".jpg"``).  Defaults to ``".png"`` for
     backward compatibility.
+
+    Retries up to 2 times on connection/timeout errors with 1s/2s backoff.
+    JSON decode errors are not retried (malformed response won't fix itself).
     """
+    max_retries = 2
     with open(image_path, "rb") as fh:
         image_b64 = base64.b64encode(fh.read()).decode("ascii")
 
@@ -415,13 +442,35 @@ def _call_ollama_suggest(image_path: Path, model: str, extension: str = ".png") 
         headers={"Content-Type": "application/json"},
     )
 
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            result = json.loads(resp.read())
-            raw = result.get("message", {}).get("content", "").strip()
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
-        logger.warning("Ollama suggest failed for %s: %s", image_path.name, exc)
-        return None
+    for attempt in range(max_retries + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                result = json.loads(resp.read())
+                raw = result.get("message", {}).get("content", "").strip()
+                break
+        except json.JSONDecodeError as exc:
+            logger.warning("Ollama returned malformed JSON for %s: %s", image_path.name, exc)
+            return None
+        except (urllib.error.URLError, OSError) as exc:
+            if attempt < max_retries:
+                wait = 2**attempt
+                logger.warning(
+                    "Ollama attempt %d/%d failed for %s, retrying in %ds: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    image_path.name,
+                    wait,
+                    exc,
+                )
+                time.sleep(wait)
+            else:
+                logger.warning(
+                    "Ollama suggest failed after %d attempts for %s: %s",
+                    max_retries + 1,
+                    image_path.name,
+                    exc,
+                )
+                return None
 
     if not raw:
         return None
@@ -453,6 +502,59 @@ def _save_settings(settings: dict[str, Any]) -> None:
     atomic_write(SETTINGS_FILE, json.dumps(settings, indent=2))
 
 
+# ── Auto-categorization helpers (4C) ──────────────────────────────────────────
+
+
+def extract_keywords(suggested_name: str) -> list[str]:
+    """Extract keywords from a kebab-case filename stem.
+
+    >>> extract_keywords("customer-onboarding-discussion.png")
+    ['customer', 'onboarding', 'discussion']
+    """
+    stem = Path(suggested_name).stem
+    return [w.lower() for w in stem.split("-") if len(w) > 2]
+
+
+def _read_decisions() -> dict[str, str]:
+    """Read state.json decisions, returning {} on miss/corruption."""
+    if STATE_FILE.exists():
+        try:
+            state = json.loads(STATE_FILE.read_text())
+            return state.get("decisions", {})
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def suggest_category(
+    keywords: list[str],
+    memory: MemoryStore,
+    decisions: dict[str, str],
+) -> Optional[str]:
+    """Return 'keep', 'trash', or None based on the user's past decisions."""
+    kw = set(keywords)
+    keep_score = 0
+    trash_score = 0
+
+    for filename, decision in decisions.items():
+        if decision not in ("keep", "trash"):
+            continue
+        rec = memory.lookup_by_name(filename)
+        if rec is None:
+            continue
+        overlap = len(kw & set(rec.meta.get("keywords", [])))
+        if decision == "keep":
+            keep_score += overlap
+        else:
+            trash_score += overlap
+
+    if keep_score > trash_score:
+        return "keep"
+    if trash_score > keep_score:
+        return "trash"
+    return None
+
+
 @app.route("/api/suggest-names", methods=["POST"])
 def api_suggest_names():
     """Generate AI filename suggestions for unprocessed screenshots."""
@@ -472,6 +574,8 @@ def api_suggest_names():
 
     memory = _get_memory()
     suggestions: dict[str, str] = {}
+    failures: list[str] = []
+    decisions = _read_decisions()
 
     for fp in fingerprints:
         rec = memory.lookup(fp)
@@ -495,13 +599,20 @@ def api_suggest_names():
 
         suggested = _call_ollama_suggest(file_path, model, rec.extension)
         if suggested:
+            keywords = extract_keywords(suggested)
+            rec.meta["keywords"] = keywords
             memory.update_suggestion(fp, suggested)
+            category = suggest_category(keywords, memory, decisions)
+            if category:
+                rec.meta["suggested_category"] = category
             suggestions[fp] = suggested
+        else:
+            failures.append(fp)
 
     if suggestions:
         memory.save()
 
-    return jsonify({"suggestions": suggestions})
+    return jsonify({"suggestions": suggestions, "failures": failures})
 
 
 @app.route("/api/accept-suggestion", methods=["POST"])
@@ -607,6 +718,7 @@ def api_get_settings():
             "llm_provider": s.get("llm_provider", "ollama"),
             "llm_model": s.get("llm_model", DEFAULT_LLM_MODEL),
             "auto_suggest": s.get("auto_suggest", False),
+            "prune_max_age_days": s.get("prune_max_age_days", 90),
         }
     )
 
@@ -614,6 +726,7 @@ def api_get_settings():
 @app.route("/api/settings", methods=["PUT"])
 def api_save_settings():
     """Save LLM/settings configuration."""
+    global _prune_max_age_cache
     if not request.is_json:
         abort(400)
     data = request.get_json(silent=True) or {}
@@ -625,8 +738,9 @@ def api_save_settings():
         "llm_provider": str,
         "llm_model": str,
         "auto_suggest": bool,
+        "prune_max_age_days": int,
     }
-    for key in ("llm_provider", "llm_model", "auto_suggest"):
+    for key in ("llm_provider", "llm_model", "auto_suggest", "prune_max_age_days"):
         if key in data:
             if not isinstance(data[key], type_checks[key]):
                 return (
@@ -640,6 +754,7 @@ def api_save_settings():
                 )
             current[key] = data[key]
     _save_settings(current)
+    _prune_max_age_cache = None
     return jsonify({"ok": True})
 
 

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -1,5 +1,6 @@
 import base64
 import contextlib
+import errno
 import json
 import logging
 import os
@@ -54,6 +55,9 @@ MEMORY_FILE = Path.home() / ".ss-dcl" / "memory.json"
 SETTINGS_FILE = Path.home() / ".ss-dcl" / "settings.json"
 DEFAULT_LLM_MODEL = "gemma4:e2b"
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+OLLAMA_HEALTH_TIMEOUT = 3  # seconds
+_OLLAMA_HEALTH_TTL = 5.0  # seconds
+_ollama_health_cache: Optional[tuple[float, bool]] = None
 # TODO Need to check if rendering changes for .tiff or .bmp needs to be handled seperately
 SUPPORTED_IMAGE_EXTENSION = (".png", ".jpg", ".jpeg", ".tiff", ".bmp")
 
@@ -409,6 +413,69 @@ def api_memory():
     return jsonify({"files": result})
 
 
+def _is_retryable_ollama_error(exc: BaseException) -> bool:
+    """Return True if *exc* is transient and worth retrying.
+
+    Unwraps ``urllib.error.URLError`` (whose ``.reason`` may itself be an
+    exception) and classifies the underlying cause.  Connection refused and
+    DNS lookup failures mean the server is down — retrying is futile — while
+    timeouts, resets, broken pipes, HTTP 429 and HTTP 5xx are transient.
+    Unrecognized errors default to retryable to stay conservative.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        # HTTPError is a URLError subclass carrying an HTTP status code.
+        return exc.code == 429 or exc.code >= 500
+
+    if isinstance(exc, urllib.error.URLError):
+        reason = exc.reason
+        if isinstance(reason, BaseException):
+            return _is_retryable_ollama_error(reason)
+        # Non-exception reason (e.g. plain string) — unknown, stay conservative.
+        return True
+
+    if isinstance(exc, (socket.timeout, TimeoutError)):
+        return True
+    if isinstance(exc, (ConnectionResetError, BrokenPipeError)):
+        return True
+    if isinstance(exc, socket.gaierror):
+        return False
+    if isinstance(exc, ConnectionRefusedError):
+        return False
+    if isinstance(exc, OSError):
+        if exc.errno == errno.ECONNREFUSED:
+            return False
+        if exc.errno in (errno.EPIPE, errno.ECONNRESET):
+            return True
+        # Unknown OSError (possibly no errno) — conservative default.
+        return True
+    return True
+
+
+def _ollama_healthy() -> bool:
+    """Cheap reachability probe (GET /api/tags).
+
+    Negative AND positive verdicts are cached for ``_OLLAMA_HEALTH_TTL``
+    seconds so a down server is probed at most once per batch instead of
+    once per file.
+    """
+    global _ollama_health_cache
+    now = time.monotonic()
+    if _ollama_health_cache is not None and now - _ollama_health_cache[0] < _OLLAMA_HEALTH_TTL:
+        return _ollama_health_cache[1]
+
+    ok = False
+    try:
+        with urllib.request.urlopen(
+            f"{OLLAMA_BASE_URL}/api/tags", timeout=OLLAMA_HEALTH_TIMEOUT
+        ) as resp:
+            ok = resp.status == 200
+    except (urllib.error.URLError, OSError):
+        ok = False
+
+    _ollama_health_cache = (time.monotonic(), ok)
+    return ok
+
+
 def _call_ollama_suggest(image_path: Path, model: str, extension: str = ".png") -> Optional[str]:
     """Call Ollama API with an image and return a suggested filename.
 
@@ -419,8 +486,10 @@ def _call_ollama_suggest(image_path: Path, model: str, extension: str = ".png") 
     the leading dot (e.g. ``".jpg"``).  Defaults to ``".png"`` for
     backward compatibility.
 
-    Retries up to 2 times on connection/timeout errors with 1s/2s backoff.
-    JSON decode errors are not retried (malformed response won't fix itself).
+    Retries up to 2 times on transient connection/timeout errors with
+    1s/2s backoff.  Permanent errors (connection refused, DNS failure,
+    HTTP 4xx) fail fast.  JSON decode errors are not retried (malformed
+    response won't fix itself).
     """
     max_retries = 2
     with open(image_path, "rb") as fh:
@@ -461,6 +530,13 @@ def _call_ollama_suggest(image_path: Path, model: str, extension: str = ".png") 
             logger.warning("Ollama returned malformed JSON for %s: %s", image_path.name, exc)
             return None
         except (urllib.error.URLError, OSError) as exc:
+            if not _is_retryable_ollama_error(exc):
+                logger.warning(
+                    "Ollama unreachable for %s, not retrying: %s",
+                    image_path.name,
+                    exc,
+                )
+                return None
             if attempt < max_retries:
                 wait = 2**attempt
                 logger.warning(
@@ -622,6 +698,14 @@ def api_suggest_names():
         memory.save()
 
     return jsonify({"suggestions": suggestions, "failures": failures})
+
+
+@app.route("/api/ollama/health")
+def api_ollama_health():
+    """Reachability check used by the frontend before running a suggest batch."""
+    ok = _ollama_healthy()
+    message = "" if ok else "Ollama is not reachable — start it with 'ollama serve' and try again."
+    return jsonify({"ok": ok, "error": message}), 200 if ok else 503
 
 
 @app.route("/api/accept-suggestion", methods=["POST"])

--- a/src/ss_dcl/memory.py
+++ b/src/ss_dcl/memory.py
@@ -264,6 +264,7 @@ class MemoryStore:
         rec.last_known_name = user_name
         rec.status = "renamed"
         rec.last_updated = _now_iso()
+        rec.meta.pop("suggested_category", None)
 
     def reject_suggestion(self, fingerprint: str) -> None:
         """Reject / dismiss the LLM suggestion (status → ``ignored``)."""
@@ -272,6 +273,7 @@ class MemoryStore:
             raise KeyError(f"Unknown fingerprint: {fingerprint}")
         rec.status = "ignored"
         rec.last_updated = _now_iso()
+        rec.meta.pop("suggested_category", None)
 
     def record_rename(self, fingerprint: str, new_name: str) -> None:
         """Record a user-initiated rename (status → ``renamed``).
@@ -287,6 +289,7 @@ class MemoryStore:
         rec.user_name = new_name
         rec.status = "renamed"
         rec.last_updated = _now_iso()
+        rec.meta.pop("suggested_category", None)
 
     def mark_trashed(self, fingerprint: str) -> None:
         """Mark a file as trashed (status → ``trashed``)."""

--- a/static/app.js
+++ b/static/app.js
@@ -62,6 +62,60 @@ let renameTarget = null;
 
 const columns = [colTrash, colUnsorted, colKeep];
 
+// ── Theme management ─────────────────────────────────────────────────────────
+const THEME_KEY = "ss-dcl-theme";
+
+function applyTheme(mode) {
+  if (mode === "dark") {
+    document.documentElement.setAttribute("data-theme", "dark");
+  } else if (mode === "light") {
+    document.documentElement.removeAttribute("data-theme");
+  } else {
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (prefersDark) {
+      document.documentElement.setAttribute("data-theme", "dark");
+    } else {
+      document.documentElement.removeAttribute("data-theme");
+    }
+  }
+}
+
+function getSavedTheme() {
+  try { return localStorage.getItem(THEME_KEY) || "auto"; } catch (_) { return "auto"; }
+}
+
+function saveTheme(mode) {
+  try { localStorage.setItem(THEME_KEY, mode); } catch (_) {}
+}
+
+function cycleTheme() {
+  const current = getSavedTheme();
+  const next = { auto: "dark", dark: "light", light: "auto" }[current] || "auto";
+  saveTheme(next);
+  applyTheme(next);
+  _updateThemeLabel();
+}
+
+function _updateThemeLabel() {
+  const btn = document.getElementById("theme-toggle");
+  if (!btn) return;
+  const mode = getSavedTheme();
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const effective = mode === "auto" ? (prefersDark ? "dark" : "light") : mode;
+  btn.setAttribute("aria-label", "Theme: " + mode + (mode === "auto" ? " (" + effective + ")" : "") + " — click to cycle");
+}
+
+applyTheme(getSavedTheme());
+window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
+  if (getSavedTheme() === "auto") applyTheme("auto");
+});
+
+document.getElementById("theme-toggle").addEventListener("click", () => {
+  cycleTheme();
+  _updateThemeLabel();
+});
+_updateThemeLabel();
+
 // ── Sanitise filenames for safe DOM insertion ────────────────────────────────
 function sanitise(str) {
   return str
@@ -73,7 +127,7 @@ function sanitise(str) {
 }
 
 // ── Settings state (loaded on init) ────────────────────────────────────────────
-let llmSettings = { llm_provider: "ollama", llm_model: "gemma4:e2b", auto_suggest: false };
+let llmSettings = { llm_provider: "ollama", llm_model: "gemma4:e2b", auto_suggest: false, prune_max_age_days: 90 };
 
 function loadSettings() {
   return fetch("/api/settings")
@@ -118,7 +172,7 @@ function loadScreenshots(savedDecisions) {
         const target = col === "trash" ? cardsTrash
                      : col === "keep"  ? cardsKeep
                      : cardsUnsorted;
-        target.appendChild(makeCard(f.name, col, f.fingerprint, f.memory_status, f.suggested_name));
+        target.appendChild(makeCard(f.name, col, f.fingerprint, f.memory_status, f.suggested_name, f.suggested_category));
       });
       updateCounts();
       saveState();
@@ -166,7 +220,7 @@ function saveState() {
 }
 
 // ── Card factory ─────────────────────────────────────────────────────────────
-function makeCard(filename, column, fingerprint, memoryStatus, suggestedName) {
+function makeCard(filename, column, fingerprint, memoryStatus, suggestedName, suggestedCategory) {
   const card = document.createElement("article");
   card.className = "card";
   card.setAttribute("role", "listitem");
@@ -175,6 +229,7 @@ function makeCard(filename, column, fingerprint, memoryStatus, suggestedName) {
   card.dataset.fingerprint = fingerprint || "";
   card.dataset.memoryStatus = memoryStatus || "";
   card.dataset.suggestedName = suggestedName || "";
+  card.dataset.suggestedCategory = suggestedCategory || null;
   card.draggable = true;
   card.tabIndex = 0;
 
@@ -188,6 +243,11 @@ function makeCard(filename, column, fingerprint, memoryStatus, suggestedName) {
   actions.className = "card-actions";
 
   card.appendChild(img);
+
+  // Category hint visual (4C)
+  if (suggestedCategory === "keep" || suggestedCategory === "trash") {
+    card.classList.add("category-hint-" + suggestedCategory);
+  }
 
   // Suggestion badge (always visible when status is "suggested")
   if (memoryStatus === "suggested" && suggestedName) {
@@ -617,6 +677,7 @@ function suggestBatch(fingerprints) {
   const chunkSize = 1;
   let completed = 0;
   let firstError = null;
+  let failedCount = 0;
 
   function processChunk(startIdx) {
     if (_suggestCancelled) {
@@ -634,11 +695,15 @@ function suggestBatch(fingerprints) {
         suggestProgressText.textContent = "No suggestions generated. Is Ollama running?";
         setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 3000);
       } else {
-        suggestProgressText.textContent = `Done! ${completed} processed`;
+        if (failedCount > 0) {
+          suggestProgressText.textContent = `Done! ${completed} processed — ${failedCount} file${failedCount > 1 ? "s" : ""} failed`;
+        } else {
+          suggestProgressText.textContent = `Done! ${completed} processed`;
+        }
         if (firstError) {
           statusMsg.textContent = firstError;
         }
-        setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 1500);
+        setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 2500);
       }
       return;
     }
@@ -657,6 +722,7 @@ function suggestBatch(fingerprints) {
           if (!firstError) firstError = data.error;
         }
         const suggestions = data.suggestions || {};
+        failedCount += (data.failures || []).length;
         for (const [fp, suggestedName] of Object.entries(suggestions)) {
           const card = document.querySelector(`[data-fingerprint="${CSS.escape(fp)}"]`);
           if (card) {
@@ -788,6 +854,8 @@ settingsBtn.addEventListener("click", () => {
   settingsProvider.value = llmSettings.llm_provider || "ollama";
   settingsModel.value = llmSettings.llm_model || "gemma4:e2b";
   settingsAuto.checked = llmSettings.auto_suggest || false;
+  const pruneAge = document.getElementById("settings-prune-age");
+  if (pruneAge) pruneAge.value = llmSettings.prune_max_age_days || 90;
   settingsModal.hidden = false;
 });
 
@@ -801,10 +869,12 @@ settingsModal.addEventListener("click", e => {
 });
 
 settingsSave.addEventListener("click", () => {
+  const pruneVal = parseInt(document.getElementById("settings-prune-age")?.value || "90", 10);
   const newSettings = {
     llm_provider: settingsProvider.value,
     llm_model: settingsModel.value.trim() || "gemma4:e2b",
     auto_suggest: settingsAuto.checked,
+    prune_max_age_days: isNaN(pruneVal) || pruneVal < 1 ? 90 : pruneVal,
   };
 
   fetch("/api/settings", {

--- a/static/app.js
+++ b/static/app.js
@@ -674,15 +674,18 @@ function suggestBatch(fingerprints) {
   if (fingerprints.length === 0) return;
 
   _suggestCancelled = false;
-  suggestAllBtn.disabled = true;
-  suggestProgress.hidden = false;
-  suggestProgressFill.style.width = "0%";
-  suggestProgressText.textContent = `0 / ${fingerprints.length}`;
 
   const chunkSize = 1;
   let completed = 0;
   let firstError = null;
   let failedCount = 0;
+
+  function abortBatch(message) {
+    suggestProgressFill.style.width = "100%";
+    suggestProgressText.textContent = message;
+    statusMsg.textContent = message;
+    setTimeout(() => { suggestProgress.hidden = true; suggestAllBtn.disabled = false; }, 4000);
+  }
 
   function processChunk(startIdx) {
     if (_suggestCancelled) {
@@ -722,9 +725,11 @@ function suggestBatch(fingerprints) {
     })
       .then(r => r.json())
       .then(data => {
-        // Check for backend-level error (e.g. unsupported provider)
+        // Backend-level error is fatal: abort the rest of the batch.
         if (data.error) {
           if (!firstError) firstError = data.error;
+          abortBatch(data.error);
+          return;
         }
         const suggestions = data.suggestions || {};
         failedCount += (data.failures || []).length;
@@ -755,7 +760,30 @@ function suggestBatch(fingerprints) {
       });
   }
 
-  processChunk(0);
+  // Pre-flight circuit breaker: bail out before any per-file calls if
+  // Ollama is down (avoids 3 futile retries per file on connection refused).
+  fetch("/api/ollama/health")
+    .then(r => r.json())
+    .then(h => {
+      if (!h.ok) {
+        statusMsg.textContent = h.error || "Couldn't reach Ollama — is it running?";
+        suggestAllBtn.disabled = false;
+        suggestProgress.hidden = true;
+        suggestProgressFill.style.width = "0%";
+        suggestProgressText.textContent = "0 / " + fingerprints.length;
+        return;
+      }
+      suggestAllBtn.disabled = true;
+      suggestProgress.hidden = false;
+      suggestProgressFill.style.width = "0%";
+      suggestProgressText.textContent = `0 / ${fingerprints.length}`;
+      processChunk(0);
+    })
+    .catch(() => {
+      statusMsg.textContent = "Couldn't reach Ollama — is it running?";
+      suggestAllBtn.disabled = false;
+      suggestProgress.hidden = true;
+    });
 }
 
 // ── Accept suggestion (rename file to suggested name) ───────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -229,7 +229,9 @@ function makeCard(filename, column, fingerprint, memoryStatus, suggestedName, su
   card.dataset.fingerprint = fingerprint || "";
   card.dataset.memoryStatus = memoryStatus || "";
   card.dataset.suggestedName = suggestedName || "";
-  card.dataset.suggestedCategory = suggestedCategory || null;
+  if (suggestedCategory) {
+    card.dataset.suggestedCategory = suggestedCategory;
+  }
   card.draggable = true;
   card.tabIndex = 0;
 
@@ -596,6 +598,9 @@ function _confirmLightboxRename() {
         card.dataset.suggestedName = "";
         const badge = card.querySelector(".suggestion-badge");
         if (badge) badge.remove();
+        // Clear category hint
+        card.classList.remove("category-hint-keep", "category-hint-trash");
+        delete card.dataset.suggestedCategory;
         const cardImg = card.querySelector("img");
         cardImg.alt = newName;
         cardImg.src = `/api/thumb/${encodeURIComponent(newName)}?t=${Date.now()}`;
@@ -787,6 +792,9 @@ function acceptSuggestion(card) {
       // Remove badge
       const badge = card.querySelector(".suggestion-badge");
       if (badge) badge.remove();
+      // Clear category hint
+      card.classList.remove("category-hint-keep", "category-hint-trash");
+      delete card.dataset.suggestedCategory;
       setCardActions(card, col);
       updateCounts();
       saveState();
@@ -811,6 +819,9 @@ function rejectSuggestion(card) {
       card.dataset.suggestedName = "";
       const badge = card.querySelector(".suggestion-badge");
       if (badge) badge.remove();
+      // Clear category hint
+      card.classList.remove("category-hint-keep", "category-hint-trash");
+      delete card.dataset.suggestedCategory;
       setCardActions(card, getCardColumn(card));
     })
     .catch(() => {});
@@ -1017,6 +1028,9 @@ renameConfirm.addEventListener("click", () => {
       renameTarget.dataset.suggestedName = "";
       const badge = renameTarget.querySelector(".suggestion-badge");
       if (badge) badge.remove();
+      // Clear category hint
+      renameTarget.classList.remove("category-hint-keep", "category-hint-trash");
+      delete renameTarget.dataset.suggestedCategory;
       const cardImg = renameTarget.querySelector("img");
       cardImg.alt = newName;
       cardImg.src = `/api/thumb/${encodeURIComponent(newName)}?t=${Date.now()}`;

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,122 @@
+/* ── Theme variables ─────────────────────────────────────── */
+:root {
+  --bg-body:              #f5f5f7;
+  --bg-header:            #fff;
+  --bg-column:            #fafafa;
+  --bg-unsorted:          #f5f5f7;
+  --bg-card:              #fff;
+  --bg-modal:             #fff;
+  --bg-modal-overlay:     rgba(0, 0, 0, 0.45);
+  --bg-progress:          #f0e6ff;
+  --bg-badge:             #f3e8ff;
+  --bg-btn-cancel:        #f0f0f0;
+  --bg-btn-cancel-hover:  #e4e4e4;
+  --bg-settings-btn:      #f0f0f0;
+  --bg-settings-btn-hover:#e0e0e0;
+  --bg-cancel-suggest:    #fff;
+  --bg-cancel-suggest-hover: #f0e6ff;
+
+  --text-primary:         #1a1a1a;
+  --text-secondary:       #666;
+  --text-muted:           #888;
+  --text-header:          inherit;
+  --text-badge:           #6b21a8;
+  --text-progress:        #6b21a8;
+  --text-btn-cancel:      #333;
+  --text-settings-btn:    #333;
+
+  --border-col:           #e5e5e5;
+  --border-header:        #e0e0e0;
+  --border-badge:         #e0d0f0;
+  --border-progress:      #e0d0f0;
+  --border-select:        #ddd;
+  --border-select-hover:  #bbb;
+
+  --shadow-card:          0 1px 6px rgba(0,0,0,.08);
+  --shadow-card-hover:    0 3px 12px rgba(0,0,0,.14);
+  --shadow-header:        0 1px 4px rgba(0,0,0,.06);
+
+  --count-bg:             #eee;
+  --count-text:           #666;
+  --count-trash-bg:       #fff0f0;
+  --count-trash-text:     #ff3b30;
+  --count-keep-bg:        #f0fff4;
+  --count-keep-text:      #34c759;
+
+  --column-title:         #888;
+  --column-trash-title:   #ff3b30;
+  --column-keep-title:    #34c759;
+
+  --lightbox-bar-bg:      rgba(0, 0, 0, 0.55);
+  --lightbox-filename:    rgba(255, 255, 255, 0.9);
+  --lightbox-filename-hover: rgba(255, 255, 255, 0.15);
+  --lightbox-rename-bg:   rgba(255, 255, 255, 0.2);
+  --lightbox-close-bg:    rgba(255, 255, 255, 0.15);
+  --lightbox-close-hover: rgba(255, 255, 255, 0.3);
+  --lightbox-backdrop:    rgba(0, 0, 0, 0.8);
+
+  --card-actions-overlay: rgba(0, 0, 0, 0.25);
+}
+
+[data-theme="dark"] {
+  --bg-body:              #1c1c1e;
+  --bg-header:            #2c2c2e;
+  --bg-column:            #242426;
+  --bg-unsorted:          #1c1c1e;
+  --bg-card:              #2c2c2e;
+  --bg-modal:             #2c2c2e;
+  --bg-modal-overlay:     rgba(0, 0, 0, 0.7);
+  --bg-progress:          #2d1f3a;
+  --bg-badge:             #2d1f3a;
+  --bg-btn-cancel:        #3a3a3c;
+  --bg-btn-cancel-hover:  #48484a;
+  --bg-settings-btn:      #3a3a3c;
+  --bg-settings-btn-hover:#48484a;
+  --bg-cancel-suggest:    #3a3a3c;
+  --bg-cancel-suggest-hover: #2d1f3a;
+
+  --text-primary:         #f5f5f7;
+  --text-secondary:       #aeaeb2;
+  --text-muted:           #8e8e93;
+  --text-header:          #f5f5f7;
+  --text-badge:           #d4a0f0;
+  --text-progress:        #d4a0f0;
+  --text-btn-cancel:      #f5f5f7;
+  --text-settings-btn:    #f5f5f7;
+
+  --border-col:           #38383a;
+  --border-header:        #38383a;
+  --border-badge:         #4a305a;
+  --border-progress:      #4a305a;
+  --border-select:        #48484a;
+  --border-select-hover:  #636366;
+
+  --shadow-card:          0 1px 6px rgba(0,0,0,.3);
+  --shadow-card-hover:    0 3px 12px rgba(0,0,0,.5);
+  --shadow-header:        0 1px 4px rgba(0,0,0,.3);
+
+  --count-bg:             #3a3a3c;
+  --count-text:           #aeaeb2;
+  --count-trash-bg:       #3d1c1c;
+  --count-trash-text:     #ff6961;
+  --count-keep-bg:        #1c3d24;
+  --count-keep-text:      #32d74b;
+
+  --column-title:         #8e8e93;
+  --column-trash-title:   #ff6961;
+  --column-keep-title:    #32d74b;
+
+  --lightbox-bar-bg:      rgba(44, 44, 46, 0.85);
+  --lightbox-filename:    rgba(245, 245, 247, 0.9);
+  --lightbox-filename-hover: rgba(245, 245, 247, 0.15);
+  --lightbox-rename-bg:   rgba(245, 245, 247, 0.15);
+  --lightbox-close-bg:    rgba(245, 245, 247, 0.15);
+  --lightbox-close-hover: rgba(245, 245, 247, 0.3);
+  --lightbox-backdrop:    rgba(0, 0, 0, 0.9);
+
+  --card-actions-overlay: rgba(0, 0, 0, 0.45);
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
@@ -6,8 +125,8 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #f5f5f7;
-  color: #1a1a1a;
+  background: var(--bg-body);
+  color: var(--text-primary);
   height: 100vh;
   overflow: hidden;
   display: flex;
@@ -23,15 +142,16 @@ header {
   align-items: center;
   justify-content: space-between;
   padding: 12px 24px;
-  background: #fff;
-  border-bottom: 1px solid #e0e0e0;
-  box-shadow: 0 1px 4px rgba(0,0,0,.06);
+  background: var(--bg-header);
+  border-bottom: 1px solid var(--border-header);
+  box-shadow: var(--shadow-header);
   flex-shrink: 0;
 }
 
 header h1 {
   font-size: 1.1rem;
   font-weight: 600;
+  color: var(--text-header);
 }
 
 .header-right {
@@ -63,24 +183,26 @@ header h1 {
   transform: none;
 }
 
-.header-settings-btn {
+.header-settings-btn,
+.header-theme-btn {
   padding: 8px 12px;
   border: none;
   border-radius: 8px;
-  background: #f0f0f0;
-  color: #333;
+  background: var(--bg-settings-btn);
+  color: var(--text-settings-btn);
   font-size: 1rem;
   cursor: pointer;
   transition: background 0.15s;
 }
 
-.header-settings-btn:hover {
-  background: #e0e0e0;
+.header-settings-btn:hover,
+.header-theme-btn:hover {
+  background: var(--bg-settings-btn-hover);
 }
 
 #status-msg {
   font-size: 0.85rem;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 #undo-btn {
@@ -118,16 +240,16 @@ header h1 {
 
 #sort-select {
   padding: 6px 10px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-select);
   border-radius: 6px;
   font-size: 0.8rem;
-  color: #333;
-  background: #fff;
+  color: var(--text-primary);
+  background: var(--bg-card);
   cursor: pointer;
 }
 
 #sort-select:hover {
-  border-color: #bbb;
+  border-color: var(--border-select-hover);
 }
 
 #done-btn:disabled {
@@ -151,7 +273,7 @@ header h1 {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-right: 1px solid #e5e5e5;
+  border-right: 1px solid var(--border-col);
 }
 
 .column:last-child {
@@ -162,12 +284,12 @@ header h1 {
 .column-keep {
   width: 22%;
   min-width: 180px;
-  background: #fafafa;
+  background: var(--bg-column);
 }
 
 .column-unsorted {
   flex: 1;
-  background: #f5f5f7;
+  background: var(--bg-unsorted);
 }
 
 /* ── Column header ───────────────────────────────────────── */
@@ -176,7 +298,7 @@ header h1 {
   align-items: center;
   justify-content: space-between;
   padding: 10px 16px;
-  border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid var(--border-col);
   flex-shrink: 0;
 }
 
@@ -185,23 +307,23 @@ header h1 {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #888;
+  color: var(--column-title);
 }
 
-.column-trash .column-title { color: #ff3b30; }
-.column-keep  .column-title { color: #34c759; }
+.column-trash .column-title { color: var(--column-trash-title); }
+.column-keep  .column-title { color: var(--column-keep-title); }
 
 .column-count {
   font-size: 0.7rem;
   font-weight: 600;
   padding: 2px 8px;
   border-radius: 10px;
-  background: #eee;
-  color: #666;
+  background: var(--count-bg);
+  color: var(--count-text);
 }
 
-.column-trash .column-count { background: #fff0f0; color: #ff3b30; }
-.column-keep  .column-count { background: #f0fff4; color: #34c759; }
+.column-trash .column-count { background: var(--count-trash-bg); color: var(--count-trash-text); }
+.column-keep  .column-count { background: var(--count-keep-bg); color: var(--count-keep-text); }
 
 /* ── Column cards container ──────────────────────────────── */
 .column-cards {
@@ -262,15 +384,15 @@ header h1 {
   position: relative;
   border-radius: 10px;
   overflow: clip;
-  background: #fff;
-  box-shadow: 0 1px 6px rgba(0,0,0,.08);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-card);
   cursor: grab;
   user-select: none;
   transition: box-shadow 0.15s ease, transform 0.15s ease;
 }
 
 .card:hover {
-  box-shadow: 0 3px 12px rgba(0,0,0,.14);
+  box-shadow: var(--shadow-card-hover);
 }
 
 .card:active {
@@ -290,6 +412,15 @@ header h1 {
   pointer-events: none;
 }
 
+/* ── Category hint (4C) ──────────────────────────────────── */
+.card.category-hint-keep {
+  border-left: 3px solid var(--count-keep-text);
+}
+
+.card.category-hint-trash {
+  border-left: 3px solid var(--count-trash-text);
+}
+
 /* ── Card action buttons overlay ─────────────────────────── */
 .card-actions {
   position: absolute;
@@ -302,7 +433,7 @@ header h1 {
   opacity: 0;
   transition: opacity 0.15s;
   pointer-events: none;
-  background: rgba(0, 0, 0, 0.25);
+  background: var(--card-actions-overlay);
   padding: 8px;
 }
 
@@ -409,13 +540,15 @@ header h1 {
 .rename-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-select);
   border-radius: 8px;
   font-size: 0.9rem;
   font-family: "SF Mono", "Menlo", "Consolas", monospace;
   margin-bottom: 6px;
   outline: none;
   transition: border-color 0.15s;
+  background: var(--bg-card);
+  color: var(--text-primary);
 }
 
 .rename-input:focus {
@@ -470,14 +603,14 @@ header h1 {
   align-items: center;
   gap: 4px;
   padding: 6px 8px;
-  background: #f3e8ff;
-  border-top: 1px solid #e0d0f0;
+  background: var(--bg-badge);
+  border-top: 1px solid var(--border-badge);
   font-size: 0.72rem;
 }
 
 .suggestion-badge-name {
   flex: 1 1 auto;
-  color: #6b21a8;
+  color: var(--text-badge);
   font-weight: 600;
   font-family: "SF Mono", "Menlo", "Consolas", monospace;
   overflow: hidden;
@@ -525,15 +658,15 @@ header h1 {
   align-items: center;
   gap: 12px;
   padding: 8px 24px;
-  background: #f0e6ff;
-  border-bottom: 1px solid #e0d0f0;
+  background: var(--bg-progress);
+  border-bottom: 1px solid var(--border-progress);
   flex-shrink: 0;
 }
 
 .suggest-progress-bar {
   flex: 1;
   height: 6px;
-  background: #e0d0f0;
+  background: var(--border-progress);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -548,17 +681,17 @@ header h1 {
 
 .suggest-progress-text {
   font-size: 0.8rem;
-  color: #6b21a8;
+  color: var(--text-progress);
   font-weight: 600;
   white-space: nowrap;
 }
 
 .suggest-cancel-btn {
   padding: 4px 12px;
-  border: 1px solid #d0c0e0;
+  border: 1px solid var(--border-badge);
   border-radius: 6px;
-  background: #fff;
-  color: #6b21a8;
+  background: var(--bg-cancel-suggest);
+  color: var(--text-progress);
   font-size: 0.75rem;
   font-weight: 600;
   cursor: pointer;
@@ -567,7 +700,7 @@ header h1 {
 }
 
 .suggest-cancel-btn:hover {
-  background: #f0e6ff;
+  background: var(--bg-cancel-suggest-hover);
 }
 
 /* ── Settings modal ─────────────────────────────────────── */
@@ -584,25 +717,29 @@ header h1 {
   display: block;
   font-size: 0.8rem;
   font-weight: 600;
-  color: #555;
+  color: var(--text-secondary);
   margin-bottom: 4px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
 .settings-field select,
-.settings-field input[type="text"] {
+.settings-field input[type="text"],
+.settings-field input[type="number"] {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-select);
   border-radius: 8px;
   font-size: 0.9rem;
   outline: none;
   transition: border-color 0.15s;
+  background: var(--bg-card);
+  color: var(--text-primary);
 }
 
 .settings-field select:focus,
-.settings-field input[type="text"]:focus {
+.settings-field input[type="text"]:focus,
+.settings-field input[type="number"]:focus {
   border-color: #007aff;
   box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.15);
 }
@@ -635,7 +772,7 @@ header h1 {
 /* ── Empty state ─────────────────────────────────────────── */
 #empty-msg {
   text-align: center;
-  color: #888;
+  color: var(--text-muted);
   margin-top: 60px;
   font-size: 1rem;
 }
@@ -658,7 +795,7 @@ header h1 {
 .lightbox-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: var(--lightbox-backdrop);
   backdrop-filter: blur(8px);
 }
 
@@ -686,7 +823,7 @@ header h1 {
   position: absolute;
   top: 16px;
   right: 20px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--lightbox-close-bg);
   border: none;
   color: #fff;
   font-size: 1.5rem;
@@ -703,7 +840,7 @@ header h1 {
 }
 
 .lightbox-close:hover {
-  background: rgba(255, 255, 255, 0.3);
+  background: var(--lightbox-close-hover);
 }
 
 /* ── Lightbox rename bar ────────────────────────────────── */
@@ -712,7 +849,7 @@ header h1 {
   flex-direction: column;
   align-items: center;
   padding: 14px 24px;
-  background: rgba(0, 0, 0, 0.55);
+  background: var(--lightbox-bar-bg);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border-radius: 14px;
@@ -722,7 +859,7 @@ header h1 {
 }
 
 .lightbox-filename {
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--lightbox-filename);
   font-size: 1rem;
   font-family: -apple-system, "SF Mono", "Menlo", monospace;
   padding: 6px 16px;
@@ -737,13 +874,13 @@ header h1 {
 }
 
 .lightbox-filename:hover {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--lightbox-filename-hover);
 }
 
 .lightbox-rename-input {
   font-size: 1rem;
   font-family: -apple-system, "SF Mono", "Menlo", "Consolas", monospace;
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--lightbox-rename-bg);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   color: #fff;
@@ -778,12 +915,12 @@ header h1 {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.45);
+  background: var(--bg-modal-overlay);
   backdrop-filter: blur(4px);
 }
 
 .modal {
-  background: #fff;
+  background: var(--bg-modal);
   border-radius: 14px;
   padding: 28px 32px 24px;
   max-width: 380px;
@@ -795,12 +932,13 @@ header h1 {
 .modal-title {
   font-size: 1.05rem;
   font-weight: 600;
+  color: var(--text-primary);
   margin-bottom: 8px;
 }
 
 .modal-desc {
   font-size: 0.85rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 24px;
   line-height: 1.5;
 }
@@ -822,12 +960,12 @@ header h1 {
 }
 
 .modal-cancel {
-  background: #f0f0f0;
-  color: #333;
+  background: var(--bg-btn-cancel);
+  color: var(--text-btn-cancel);
 }
 
 .modal-cancel:hover {
-  background: #e4e4e4;
+  background: var(--bg-btn-cancel-hover);
 }
 
 .modal-confirm {
@@ -838,6 +976,12 @@ header h1 {
 .modal-confirm:hover {
   background: #e0342a;
 }
+
+/* ── Theme toggle icon visibility ───────────────────────── */
+[data-theme="dark"] .theme-icon-light { display: none; }
+[data-theme="dark"] .theme-icon-dark  { display: inline; }
+:root .theme-icon-dark  { display: none; }
+:root .theme-icon-light { display: inline; }
 
 .sr-only {
   position: absolute;
@@ -875,7 +1019,7 @@ header h1 {
 
   .column {
     border-right: none;
-    border-bottom: 1px solid #e5e5e5;
+    border-bottom: 1px solid var(--border-col);
     max-height: 40vh;
   }
 

--- a/static/style.css
+++ b/static/style.css
@@ -978,10 +978,10 @@ header h1 {
 }
 
 /* ── Theme toggle icon visibility ───────────────────────── */
-[data-theme="dark"] .theme-icon-light { display: none; }
-[data-theme="dark"] .theme-icon-dark  { display: inline; }
 :root .theme-icon-dark  { display: none; }
 :root .theme-icon-light { display: inline; }
+[data-theme="dark"] .theme-icon-light { display: none; }
+[data-theme="dark"] .theme-icon-dark  { display: inline; }
 
 .sr-only {
   position: absolute;

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,10 @@
         <option value="size_desc">Largest first</option>
       </select>
       <button id="suggest-all-btn" class="header-suggest-btn" aria-label="Suggest names for all new screenshots">✨ Suggest All</button>
+      <button id="theme-toggle" class="header-theme-btn" aria-label="Toggle dark mode">
+        <span class="theme-icon-light">☀</span>
+        <span class="theme-icon-dark">☾</span>
+      </button>
       <button id="undo-btn" disabled aria-label="Undo last move">Undo</button>
       <button id="done-btn" disabled aria-label="Move screenshots to trash">Done</button>
       <button id="settings-btn" class="header-settings-btn" aria-label="Open settings">⚙</button>
@@ -129,6 +133,10 @@
         <div class="settings-field settings-field-toggle">
           <label for="settings-auto">Auto-suggest on scan</label>
           <input id="settings-auto" type="checkbox" />
+        </div>
+        <div class="settings-field">
+          <label for="settings-prune-age">Prune memory after (days)</label>
+          <input id="settings-prune-age" type="number" min="1" max="730" class="rename-input" />
         </div>
       </div>
       <div class="modal-actions">

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -252,3 +252,61 @@ def test_rename_handlers_remove_suggestion_badge(client):
     assert b"if (badge) badge.remove()" in r.data
     # Modal rename sets suggestedName to empty
     assert b'suggestedName = ""' in r.data
+
+
+# ── Phase 4B: Dark mode ─────────────────────────────────────────────────────
+
+
+def test_index_has_theme_toggle(client):
+    """#theme-toggle button exists in HTML."""
+    c, _ = client
+    html = c.get("/").data.decode()
+    assert 'id="theme-toggle"' in html
+
+
+def test_app_js_has_theme_cycle(client):
+    """JS must define cycleTheme or THEME_KEY for theme management."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"THEME_KEY" in r.data
+    assert b"function cycleTheme(" in r.data
+
+
+def test_css_has_dark_variables(client):
+    """CSS must have [data-theme="dark"] block with --bg-body."""
+    c, _ = client
+    r = c.get("/static/style.css")
+    assert r.status_code == 200
+    assert b'[data-theme="dark"]' in r.data
+    assert b"--bg-body" in r.data
+
+
+def test_css_has_light_variables(client):
+    """CSS must have :root block with CSS custom properties."""
+    c, _ = client
+    r = c.get("/static/style.css")
+    assert r.status_code == 200
+    assert b":root {" in r.data
+    assert b"--bg-body" in r.data
+
+
+# ── Phase 4C/4D: Frontend hints + failure count ──────────────────────────────
+
+
+def test_css_has_category_hint_styles(client):
+    """CSS must define .category-hint-keep/-trash rules."""
+    c, _ = client
+    r = c.get("/static/style.css")
+    assert r.status_code == 200
+    assert b"category-hint-keep" in r.data
+    assert b"category-hint-trash" in r.data
+
+
+def test_app_js_shows_failure_count(client):
+    """JS must reference failures.length for showing failure count."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"failedCount" in r.data
+    assert b"failures" in r.data

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -1495,3 +1495,123 @@ def test_call_ollama_suggest_no_retry_on_bad_json(tmp_path, monkeypatch):
     assert result is None
     assert call_count == 1, "JSONDecodeError should not retry"
     assert not sleep_called, "No sleep on JSON error"
+
+
+# ── Bug fix: category hint clearing ─────────────────────────────────────────
+
+
+def test_accept_clears_suggested_category_in_meta(client):
+    """Accepting a suggestion clears meta.suggested_category."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    # Manually set suggested_category on the record
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    rec.suggested_name = "customer-onboarding.png"
+    rec.meta["suggested_category"] = "keep"
+
+    assert rec.meta.get("suggested_category") == "keep"
+
+    c.post(
+        "/api/accept-suggestion",
+        data=json.dumps({"fingerprint": fp}),
+        content_type="application/json",
+    )
+
+    rec = memory.lookup(fp)
+    assert rec.meta.get("suggested_category") is None
+
+
+def test_reject_clears_suggested_category_in_meta(client):
+    """Rejecting a suggestion clears meta.suggested_category."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    rec.meta["suggested_category"] = "keep"
+
+    assert rec.meta.get("suggested_category") == "keep"
+
+    c.post(
+        "/api/reject-suggestion",
+        data=json.dumps({"fingerprint": fp}),
+        content_type="application/json",
+    )
+
+    rec = memory.lookup(fp)
+    assert rec.meta.get("suggested_category") is None
+
+
+def test_rename_clears_suggested_category_in_meta(client):
+    """Renaming a file clears meta.suggested_category."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    rec.meta["suggested_category"] = "trash"
+
+    assert rec.meta.get("suggested_category") == "trash"
+
+    c.post(
+        "/api/rename",
+        data=json.dumps(
+            {
+                "old_name": f.name,
+                "new_name": "renamed-screenshot.png",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    rec = memory.lookup(fp)
+    assert rec.meta.get("suggested_category") is None
+
+
+def test_accept_clears_category_hint_in_frontend(client, monkeypatch):
+    """acceptSuggestion() must remove .category-hint-* class and dataset."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    # acceptSuggestion path
+    assert b"category-hint-keep" in r.data
+    assert b"category-hint-trash" in r.data
+    # Must appear in the accept path (after the badge removal comment)
+    assert b"delete card.dataset.suggestedCategory" in r.data
+
+
+def test_reject_clears_category_hint_in_frontend(client):
+    """rejectSuggestion() must remove .category-hint-* class and dataset."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    # rejectSuggestion references remove + delete after the badge removal
+    # Count: delete card.dataset.suggestedCategory must appear at least twice
+    # (once in accept, once in reject)
+    assert r.data.count(b"delete card.dataset.suggestedCategory") >= 2
+
+
+def test_rename_clears_category_hint_in_frontend(client):
+    """Both rename paths must clear category hint class and dataset."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    # 3 occurrences: accept + reject + lightbox rename
+    # (modal rename uses renameTarget.dataset)
+    assert r.data.count(b"delete card.dataset.suggestedCategory") >= 3
+    # Modal rename path also clears
+    assert b"delete renameTarget.dataset.suggestedCategory" in r.data

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -11,6 +11,7 @@ Tests that:
 """
 
 import json
+import socket
 import urllib.error
 from unittest.mock import patch
 
@@ -1407,8 +1408,33 @@ def test_suggest_names_empty_failures_on_success(client, monkeypatch):
     assert fp in data["suggestions"]
 
 
-def test_call_ollama_suggest_retries_on_url_error(tmp_path, monkeypatch):
-    """Retries up to max_retries times on URLError before giving up."""
+def test_call_ollama_suggest_fails_fast_on_connection_refused(tmp_path, monkeypatch):
+    """Connection refused (Errno 61) is permanent — no retries, no backoff sleep."""
+    img = tmp_path / "test.png"
+    img.write_bytes(b"fake-data")
+
+    call_count = 0
+    sleeps = []
+
+    def mock_urlopen(req, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        raise urllib.error.URLError(ConnectionRefusedError(61, "Connection refused"))
+
+    def mock_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(flask_app.urllib.request, "urlopen", mock_urlopen)
+    monkeypatch.setattr(flask_app.time, "sleep", mock_sleep)
+
+    result = flask_app._call_ollama_suggest(img, "test-model")
+    assert result is None
+    assert call_count == 1, "connection refused should fail fast (no retries)"
+    assert len(sleeps) == 0, "no backoff sleep for a permanent error"
+
+
+def test_call_ollama_suggest_retries_on_transient_error(tmp_path, monkeypatch):
+    """Unrecognized URLError stays retryable — 3 attempts before giving up."""
     img = tmp_path / "test.png"
     img.write_bytes(b"fake-data")
 
@@ -1417,7 +1443,7 @@ def test_call_ollama_suggest_retries_on_url_error(tmp_path, monkeypatch):
     def mock_urlopen(req, timeout=None):
         nonlocal call_count
         call_count += 1
-        raise urllib.error.URLError("connection refused")
+        raise urllib.error.URLError("temporary failure")
 
     monkeypatch.setattr(flask_app.urllib.request, "urlopen", mock_urlopen)
     monkeypatch.setattr(flask_app.time, "sleep", lambda s: None)
@@ -1425,6 +1451,119 @@ def test_call_ollama_suggest_retries_on_url_error(tmp_path, monkeypatch):
     result = flask_app._call_ollama_suggest(img, "test-model")
     assert result is None
     assert call_count == 3  # initial + 2 retries = 3 attempts
+
+
+def test_is_retryable_ollama_error_classifier():
+    """_is_retryable_ollama_error classifies transient vs permanent errors."""
+    # Not retryable: connection refused, DNS failure, 4xx (except 429)
+    assert not flask_app._is_retryable_ollama_error(
+        ConnectionRefusedError(61, "Connection refused")
+    )
+    assert not flask_app._is_retryable_ollama_error(
+        urllib.error.URLError(ConnectionRefusedError(61, "Connection refused"))
+    )
+    assert not flask_app._is_retryable_ollama_error(socket.gaierror())
+    assert not flask_app._is_retryable_ollama_error(
+        urllib.error.HTTPError("http://x/api/chat", 404, "Not Found", None, None)
+    )
+    assert not flask_app._is_retryable_ollama_error(
+        urllib.error.HTTPError("http://x/api/chat", 400, "Bad Request", None, None)
+    )
+
+    # Retryable: timeouts, resets, broken pipes, 429, 5xx, unknown errors
+    assert flask_app._is_retryable_ollama_error(socket.timeout())
+    assert flask_app._is_retryable_ollama_error(TimeoutError())
+    assert flask_app._is_retryable_ollama_error(
+        ConnectionResetError(54, "Connection reset by peer")
+    )
+    assert flask_app._is_retryable_ollama_error(BrokenPipeError(32, "Broken pipe"))
+    assert flask_app._is_retryable_ollama_error(
+        urllib.error.HTTPError("http://x/api/chat", 429, "Too Many Requests", None, None)
+    )
+    assert flask_app._is_retryable_ollama_error(
+        urllib.error.HTTPError("http://x/api/chat", 500, "Server Error", None, None)
+    )
+    assert flask_app._is_retryable_ollama_error(urllib.error.URLError("temporary failure"))
+    assert flask_app._is_retryable_ollama_error(OSError("temporary failure"))
+
+
+class _FakeHealthResponse:
+    """Minimal stand-in for urllib response with .status and a .read()."""
+
+    def __init__(self, status):
+        self.status = status
+
+    def read(self):
+        return b"{}"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return None
+
+
+def test_ollama_healthy_true_on_200(monkeypatch):
+    """GET /api/tags returning 200 → healthy."""
+    monkeypatch.setattr(flask_app, "_ollama_health_cache", None)
+    monkeypatch.setattr(
+        flask_app.urllib.request, "urlopen", lambda url, timeout=None: _FakeHealthResponse(200)
+    )
+
+    assert flask_app._ollama_healthy() is True
+
+
+def test_ollama_healthy_false_on_connection_refused(monkeypatch):
+    """Connection refused → unhealthy."""
+
+    def mock_urlopen(url, timeout=None):
+        raise urllib.error.URLError(ConnectionRefusedError(61, "Connection refused"))
+
+    monkeypatch.setattr(flask_app, "_ollama_health_cache", None)
+    monkeypatch.setattr(flask_app.urllib.request, "urlopen", mock_urlopen)
+
+    assert flask_app._ollama_healthy() is False
+
+
+def test_ollama_healthy_caches_negative_verdict(monkeypatch):
+    """A False verdict is cached for the TTL even if the server comes back."""
+    calls = []
+
+    def mock_urlopen(url, timeout=None):
+        calls.append(1)
+        raise urllib.error.URLError(ConnectionRefusedError(61, "Connection refused"))
+
+    monkeypatch.setattr(flask_app, "_ollama_health_cache", None)
+    monkeypatch.setattr(flask_app.urllib.request, "urlopen", mock_urlopen)
+
+    assert flask_app._ollama_healthy() is False
+    assert len(calls) == 1
+
+    # Server "comes back", but the cached False verdict is still fresh.
+    monkeypatch.setattr(
+        flask_app.urllib.request, "urlopen", lambda url, timeout=None: _FakeHealthResponse(200)
+    )
+    assert flask_app._ollama_healthy() is False  # served from cache
+    assert len(calls) == 1
+
+
+def test_ollama_health_route(client, monkeypatch):
+    """GET /api/ollama/health returns 200 when healthy, 503 when not."""
+    c, _ = client
+
+    monkeypatch.setattr(flask_app, "_ollama_healthy", lambda: True)
+    r = c.get("/api/ollama/health")
+    assert r.status_code == 200
+    data = json.loads(r.data)
+    assert data["ok"] is True
+    assert data["error"] == ""
+
+    monkeypatch.setattr(flask_app, "_ollama_healthy", lambda: False)
+    r = c.get("/api/ollama/health")
+    assert r.status_code == 503
+    data = json.loads(r.data)
+    assert data["ok"] is False
+    assert data["error"]  # non-empty error message
 
 
 def test_call_ollama_suggest_succeeds_on_retry(tmp_path, monkeypatch):

--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -11,6 +11,7 @@ Tests that:
 """
 
 import json
+import urllib.error
 from unittest.mock import patch
 
 import src.ss_dcl.app as flask_app
@@ -263,7 +264,7 @@ def test_suggest_names_unknown_fingerprints_return_empty(client):
         content_type="application/json",
     )
     assert r.status_code == 200
-    assert json.loads(r.data) == {"suggestions": {}}
+    assert json.loads(r.data) == {"suggestions": {}, "failures": []}
 
 
 def test_suggest_names_rejects_non_json(client):
@@ -281,7 +282,7 @@ def test_suggest_names_rejects_missing_fingerprints(client):
     )
     # fingerprints defaults to [] and is a list, so it passes validation
     assert r.status_code == 200
-    assert json.loads(r.data) == {"suggestions": {}}
+    assert json.loads(r.data) == {"suggestions": {}, "failures": []}
 
 
 def test_suggest_names_rejects_non_list_fingerprints(client):
@@ -549,7 +550,7 @@ def test_suggest_names_skips_already_processed(client, monkeypatch):
         content_type="application/json",
     )
     assert r.status_code == 200
-    assert json.loads(r.data) == {"suggestions": {}}
+    assert json.loads(r.data) == {"suggestions": {}, "failures": []}
     assert call_count == 0  # LLM never called for ignored files
 
 
@@ -573,7 +574,7 @@ def test_suggest_names_handles_llm_returning_none(client, monkeypatch):
         content_type="application/json",
     )
     assert r.status_code == 200
-    assert json.loads(r.data) == {"suggestions": {}}
+    assert json.loads(r.data) == {"suggestions": {}, "failures": [fp]}
 
     # Status should remain "new" (unchanged)
     memory = flask_app._get_memory()
@@ -588,7 +589,7 @@ def test_suggest_names_unknown_fingerprint_skipped(client, monkeypatch):
         content_type="application/json",
     )
     assert r.status_code == 200
-    assert json.loads(r.data) == {"suggestions": {}}
+    assert json.loads(r.data) == {"suggestions": {}, "failures": []}
 
 
 # ── /api/accept-suggestion ─────────────────────────────────────────────────
@@ -1048,3 +1049,449 @@ def test_suggest_names_preserves_non_png_extension(client, monkeypatch):
     )
     assert r.status_code == 200
     assert json.loads(r.data)["suggestions"][fp] == "beach-photo.jpg"
+
+
+# ── Phase 4A: Memory pruning / GC ──────────────────────────────────────────
+
+
+def test_scan_triggers_prune_stale(client):
+    """After scanning, orphaned entries beyond max age are removed from memory."""
+    c, desktop = client
+
+    # Create a file and scan it to populate memory
+    f = desktop / "Screenshot fresh.png"
+    f.write_bytes(b"fresh")
+    c.get("/api/screenshots")
+
+    # Create a stale orphan entry directly in memory (pretend it was trashed long ago)
+    memory = flask_app._get_memory()
+    orphan = memory.record_file("Screenshot old-orphan.png", 9999)
+    orphan.status = "trashed"
+    # Backdate last_updated to 100 days ago
+    from datetime import datetime, timedelta, timezone
+
+    orphan.last_updated = (datetime.now(tz=timezone.utc) - timedelta(days=100)).isoformat()
+    memory.save()
+
+    assert memory.lookup(orphan.fingerprint) is not None
+
+    # Force prune max age to 90 days (default) — orphan is 100 days old → pruned
+    flask_app._reset_memory()
+    c.get("/api/screenshots")
+
+    memory = flask_app._get_memory()
+    assert memory.lookup(orphan.fingerprint) is None, "100-day-old orphan should be pruned"
+
+
+def test_prune_respects_settings_age(client):
+    """Changing prune_max_age_days in settings affects what gets pruned."""
+    c, desktop = client
+
+    # Set a short max age (1 day)
+    c.put(
+        "/api/settings",
+        data=json.dumps({"prune_max_age_days": 1}),
+        content_type="application/json",
+    )
+
+    f = desktop / "Screenshot active.png"
+    f.write_bytes(b"active")
+    c.get("/api/screenshots")
+
+    # Create an orphan trashed 5 days ago
+    memory = flask_app._get_memory()
+    orphan = memory.record_file("Screenshot old.png", 8888)
+    orphan.status = "trashed"
+    from datetime import datetime, timedelta, timezone
+
+    orphan.last_updated = (datetime.now(tz=timezone.utc) - timedelta(days=5)).isoformat()
+    memory.save()
+
+    flask_app._reset_memory()
+    c.get("/api/screenshots")
+
+    memory = flask_app._get_memory()
+    assert memory.lookup(orphan.fingerprint) is None, (
+        "5-day-old orphan should be pruned with max_age=1"
+    )
+
+
+def test_prune_keeps_active_entries(client):
+    """Files still on disk are never pruned regardless of age."""
+    c, desktop = client
+
+    f = desktop / "Screenshot ancient.png"
+    f.write_bytes(b"old but alive")
+    c.get("/api/screenshots")
+
+    # Backdate the record to 200 days ago
+    memory = flask_app._get_memory()
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+    rec = memory.lookup(fp)
+    from datetime import datetime, timedelta, timezone
+
+    rec.last_updated = (datetime.now(tz=timezone.utc) - timedelta(days=200)).isoformat()
+    memory.save()
+
+    flask_app._reset_memory()
+    c.get("/api/screenshots")
+
+    memory = flask_app._get_memory()
+    assert memory.lookup(fp) is not None, "Active file should never be pruned"
+
+
+def test_prune_keeps_renamed_on_disk(client):
+    """A renamed file still on disk is treated as active and never pruned."""
+    c, desktop = client
+    old = desktop / "Screenshot original.png"
+    old.write_bytes(_make_png(10, 10))
+
+    # Scan → record
+    c.get("/api/screenshots")
+
+    # Rename
+    c.post(
+        "/api/rename",
+        data=json.dumps({"old_name": old.name, "new_name": "Screenshot renamed-on-disk.png"}),
+        content_type="application/json",
+    )
+
+    # The renamed file should still be considered active
+    flask_app._reset_memory()
+    r = c.get("/api/screenshots")
+    files = json.loads(r.data)
+    assert len(files) == 1
+    assert files[0]["name"] == "Screenshot renamed-on-disk.png"
+    # The record must still exist (not pruned)
+    memory = flask_app._get_memory()
+    rec = memory.lookup_by_name("Screenshot renamed-on-disk.png")
+    assert rec is not None, "Renamed file on disk should not be pruned"
+
+
+def test_prune_keeps_recent_inactive(client):
+    """Files trashed 5 days ago are kept when max_age=90."""
+    c, desktop = client
+
+    f = desktop / "Screenshot recent-trash.png"
+    f.write_bytes(b"data")
+    c.get("/api/screenshots")
+
+    memory = flask_app._get_memory()
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+    rec = memory.lookup(fp)
+    from datetime import datetime, timedelta, timezone
+
+    rec.status = "trashed"
+    rec.last_updated = (datetime.now(tz=timezone.utc) - timedelta(days=5)).isoformat()
+    memory.save()
+
+    # Remove file from disk (simulating trash)
+    f.unlink()
+
+    flask_app._reset_memory()
+    c.get("/api/screenshots")
+
+    memory = flask_app._get_memory()
+    assert memory.lookup(fp) is not None, (
+        "Recently trashed file should be kept within 90-day window"
+    )
+
+
+def test_save_settings_invalidates_prune_cache(client):
+    """After saving prune_max_age_days, the cached value is refreshed."""
+    c, _ = client
+
+    # Set a non-default value
+    c.put(
+        "/api/settings",
+        data=json.dumps({"prune_max_age_days": 7}),
+        content_type="application/json",
+    )
+
+    # The cache should be invalidated; next call reads fresh
+    # Verify the settings round-trip
+    r = c.get("/api/settings")
+    assert json.loads(r.data)["prune_max_age_days"] == 7
+
+
+def test_settings_prune_age_roundtrip(client):
+    """Save → load preserves prune_max_age_days."""
+    c, _ = client
+    c.put(
+        "/api/settings",
+        data=json.dumps({"prune_max_age_days": 30}),
+        content_type="application/json",
+    )
+    r = c.get("/api/settings")
+    assert json.loads(r.data)["prune_max_age_days"] == 30
+
+
+def test_settings_prune_age_type_validation(client):
+    """Non-integer prune_max_age_days values are rejected."""
+    c, _ = client
+    r = c.put(
+        "/api/settings",
+        data=json.dumps({"prune_max_age_days": "not-a-number"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+# ── Phase 4C: Auto-categorization ──────────────────────────────────────────
+
+
+def test_extract_keywords_from_suggested_name():
+    """extract_keywords parses kebab-case filename stems."""
+    assert flask_app.extract_keywords("foo-bar-baz.png") == ["foo", "bar", "baz"]
+
+
+def test_extract_keywords_filters_short_words():
+    """Words with length <= 2 are filtered out."""
+    assert flask_app.extract_keywords("a-b-cat.png") == ["cat"]
+
+
+def test_suggest_category_no_decisions_returns_none(client):
+    """Empty decisions → no categorization."""
+    _, _t = client
+    memory = flask_app._get_memory()
+    result = flask_app.suggest_category(["foo", "bar"], memory, {})
+    assert result is None
+
+
+def test_suggest_category_keep_when_keywords_match_kept(client):
+    """Files marked 'keep' in decisions with matching keywords → 'keep'."""
+    _, _t = client
+    memory = flask_app._get_memory()
+
+    # Create a memory record for a file that was kept
+    rec = memory.record_file("kept-file.png", 100)
+    rec.meta["keywords"] = ["customer", "onboarding"]
+
+    decisions = {"kept-file.png": "keep"}
+    result = flask_app.suggest_category(["customer", "discussion"], memory, decisions)
+    assert result == "keep"
+
+
+def test_suggest_category_trash_when_keywords_match_trashed(client):
+    """Files marked 'trash' in decisions with matching keywords → 'trash'."""
+    _, _t = client
+    memory = flask_app._get_memory()
+
+    rec = memory.record_file("trashed-file.png", 200)
+    rec.meta["keywords"] = ["meme", "funny"]
+
+    decisions = {"trashed-file.png": "trash"}
+    result = flask_app.suggest_category(["funny", "joke"], memory, decisions)
+    assert result == "trash"
+
+
+def test_suggest_category_ignores_renamed_but_undecided(client):
+    """A renamed (but undecided) file does not count as a keep signal."""
+    _, _t = client
+    memory = flask_app._get_memory()
+
+    # Create a file that was renamed (not in decisions)
+    rec = memory.record_file("renamed-file.png", 300)
+    rec.meta["keywords"] = ["work", "report"]
+    rec.status = "renamed"
+
+    decisions = {}  # Not decided → should not contribute
+    result = flask_app.suggest_category(["work"], memory, decisions)
+    assert result is None
+
+
+def test_suggest_category_tie_returns_none(client):
+    """Equal keep/trash scores → None."""
+    _, _t = client
+    memory = flask_app._get_memory()
+
+    rec1 = memory.record_file("kept.png", 100)
+    rec1.meta["keywords"] = ["shared"]
+    rec2 = memory.record_file("trashed.png", 200)
+    rec2.meta["keywords"] = ["shared"]
+
+    decisions = {"kept.png": "keep", "trashed.png": "trash"}
+    result = flask_app.suggest_category(["shared"], memory, decisions)
+    assert result is None
+
+
+def test_suggest_names_stores_keywords_in_meta(client, monkeypatch):
+    """After LLM suggest, rec.meta.keywords is populated."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    def mock_suggest(image_path, model, extension=".png"):
+        return "customer-onboarding-discussion" + extension
+
+    monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
+
+    c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": [fp]}),
+        content_type="application/json",
+    )
+
+    memory = flask_app._get_memory()
+    rec = memory.lookup(fp)
+    assert rec.meta.get("keywords") == ["customer", "onboarding", "discussion"]
+
+
+def test_screenshots_includes_suggested_category(client, monkeypatch):
+    """Response includes suggested_category field."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    c.get("/api/screenshots")
+    r = c.get("/api/screenshots")
+    file_data = json.loads(r.data)[0]
+    # Without any suggestion, field should be None
+    assert "suggested_category" in file_data
+    assert file_data["suggested_category"] is None
+
+
+# ── Phase 4D: LLM retry / error recovery ────────────────────────────────────
+
+
+def test_suggest_names_returns_failures_list(client, monkeypatch):
+    """Failures appear in response when LLM returns None."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    def mock_suggest(image_path, model, extension=".png"):
+        return None
+
+    monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
+
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": [fp]}),
+        content_type="application/json",
+    )
+    data = json.loads(r.data)
+    assert data["suggestions"] == {}
+    assert data["failures"] == [fp]
+
+
+def test_suggest_names_empty_failures_on_success(client, monkeypatch):
+    """failures: [] when all succeed."""
+    c, desktop = client
+    f = desktop / "Screenshot 2024-01-01 at 12.00.00 PM.png"
+    f.write_bytes(_make_png(10, 10))
+
+    r = c.get("/api/screenshots")
+    fp = json.loads(r.data)[0]["fingerprint"]
+
+    def mock_suggest(image_path, model, extension=".png"):
+        return "good-suggestion" + extension
+
+    monkeypatch.setattr(flask_app, "_call_ollama_suggest", mock_suggest)
+
+    r = c.post(
+        "/api/suggest-names",
+        data=json.dumps({"fingerprints": [fp]}),
+        content_type="application/json",
+    )
+    data = json.loads(r.data)
+    assert data["failures"] == []
+    assert fp in data["suggestions"]
+
+
+def test_call_ollama_suggest_retries_on_url_error(tmp_path, monkeypatch):
+    """Retries up to max_retries times on URLError before giving up."""
+    img = tmp_path / "test.png"
+    img.write_bytes(b"fake-data")
+
+    call_count = 0
+
+    def mock_urlopen(req, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(flask_app.urllib.request, "urlopen", mock_urlopen)
+    monkeypatch.setattr(flask_app.time, "sleep", lambda s: None)
+
+    result = flask_app._call_ollama_suggest(img, "test-model")
+    assert result is None
+    assert call_count == 3  # initial + 2 retries = 3 attempts
+
+
+def test_call_ollama_suggest_succeeds_on_retry(tmp_path, monkeypatch):
+    """Second attempt succeeds → returns suggestion."""
+    import json as _json
+
+    img = tmp_path / "test.png"
+    img.write_bytes(b"fake-data")
+
+    call_count = 0
+
+    class FakeResponse:
+        def read(self):
+            return _json.dumps({"message": {"content": "retry-success"}}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def mock_urlopen(req, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("temporary failure")
+        return FakeResponse()
+
+    monkeypatch.setattr(flask_app.urllib.request, "urlopen", mock_urlopen)
+    monkeypatch.setattr(flask_app.time, "sleep", lambda s: None)
+
+    result = flask_app._call_ollama_suggest(img, "test-model")
+    assert result == "retry-success.png"
+    assert call_count == 2
+
+
+def test_call_ollama_suggest_no_retry_on_bad_json(tmp_path, monkeypatch):
+    """JSONDecodeError fails fast (no retry, no sleep)."""
+    img = tmp_path / "test.png"
+    img.write_bytes(b"fake-data")
+
+    call_count = 0
+    sleep_called = False
+
+    class BadResponse:
+        def read(self):
+            return b"not json at all"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def mock_urlopen(req, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        return BadResponse()
+
+    def mock_sleep(s):
+        nonlocal sleep_called
+        sleep_called = True
+
+    monkeypatch.setattr(flask_app.urllib.request, "urlopen", mock_urlopen)
+    monkeypatch.setattr(flask_app.time, "sleep", mock_sleep)
+
+    result = flask_app._call_ollama_suggest(img, "test-model")
+    assert result is None
+    assert call_count == 1, "JSONDecodeError should not retry"
+    assert not sleep_called, "No sleep on JSON error"

--- a/tools/prompt-ocr-to-filename.md
+++ b/tools/prompt-ocr-to-filename.md
@@ -1,0 +1,121 @@
+# OCR → Filename Prompt — For Text-Only LLM Testing
+
+Use this prompt with any small text-only LLM (SmolLM, Qwen 2.5 1.5B, Gemma 2
+2B, Llama 3.2 1B, etc.) running locally via Ollama or similar.  The model
+never sees the image — only the raw OCR output from Tesseract.
+
+Copy the entire prompt block below and paste it into the model, replacing
+`{ocr_text}` with the actual OCR output.
+
+---
+
+## Prompt
+
+```
+You are a screenshot-to-filename converter.  Below is raw text extracted
+from a macOS screenshot via Tesseract OCR.  The text may be:
+
+- Messy — UI chrome (buttons, timestamps, phone numbers) mixed with real content
+- Garbled — image-heavy screenshots produce mostly noise (you will see this)
+- Clean — text-chat screenshots produce excellent output
+- Truncated — OCR may miss words at edges or from weird font rendering
+
+Your job is to produce a 3-4 word, lowercase, hyphen-separated filename
+that captures THE ESSENCE of what the screenshot is about.
+
+Rules:
+1. Output ONLY the filename.  No quotes, no markdown, no explanation.
+2. If the OCR is mostly garbled, still try — look for ANY recognisable
+   word, app name, or pattern.  If truly hopeless, output "screenshot".
+3. Prioritise TOPIC over FORMAT.  "salary-delay-messages" is better
+   than "imessage-dark-mode".
+4. Names of people in chats are CLUES, not the answer.  "Manoj asks
+   about RCA deadline" → "onboarding-deadline-reminder", not "manoj-
+   chandra-message".
+
+=== EXAMPLES (real OCR from macOS screenshots) ===
+
+EXAMPLE 1 — Slack chat about customer onboarding
+OCR TEXT:
+  Manoj Chandra Bhamidipati @Ravi Ankam, if the stable RCA is not
+  completed before Sunday, please proceed with proper reliving
+  transition to the entire Al team. @Yuva Teja Bandharapu, @Guru,
+  @Osho Kothari, and @Vivek, | expect to receive positive
+  responses from onboarded customers by Monday morning. | will
+  work alongside Al. @Bharat FY!
+  ood
+  Si
+  oO S& S& Sreplies Last reply today at 7:31 PM
+FILENAME: customer-onboarding-deadline
+
+EXAMPLE 2 — iMessage chat about delayed salary
+OCR TEXT:
+  a Cee a Mas SND CN SS OE TS NS OG NS eee Te ee
+  10 MAYOS KN WASH NXCO 1:20PM
+  +9199124 20002
+  ~Bhamidipati Manoj
+  Hi Guru, ur
+  lary will be settled by next week Wednesday. Im very sorry for
+  delay. Arranging funds for next 3 months. It will not happen again
+  Hi Manoj , any updates on this ? Is it already processed from your side
+  2:31PM
+  'On it, | will update by eod 9:31 py
+  It will done
+  sap. Sorry for delay. 2:35 pM
+  Not more than 48. Hours 2:35PM
+FILENAME: salary-delay-messages
+
+EXAMPLE 3 — Slack chat about employment status
+OCR TEXT:
+  Guru, | saw ur profile says open to work. Please remove that. If
+  don't like to work here please find another one. Don't use BugRaid
+  name. It is ok to switch
+  12:45AM
+  «
+  Iwill remove that then 49.26 any
+  Im not asking to remove, keeping open to work either degrade company
+  or you. You can pick ur choice
+  12:47 AM
+  Ican understand ur undervalue at the moment, things will change. But
+  u can take decision anytime
+  12:48 AM
+FILENAME: open-to-work-dispute
+
+EXAMPLE 4 — Video call (FaceTime) — mostly garbled
+OCR TEXT:
+  | / . ae - > ue ed ae Lae ae
+  4 iW 4 tes c 3 a 3
+  zg > TM & Create Link New FaceTime Sei aes »| gM J ,
+  re yg x
+  Mow ia ' >
+  i A . : '
+  ] ee @ > +1(800) 660-2737 : ~
+  A | - | @ <2 Pas -
+  .. ! «x = - : | Last Week z
+  ; j fw) FR. be Pe ; - eS
+  Col aan . = |
+  & , a, ' af - j
+  1 | . s Z
+  . a @ 5 s
+  ee om 7 } | 80: ae
+  184 5895
+  it ~ - = q This Month
+  | =
+  7 P oa ' rll = @ = 83711393
+  4 ' ' 3 ; "4 @ (c)3525 3
+  : , - re : ' | 'a e 9868 7824
+  - = manyc a= a
+  i Boy Mom
+  4 - EscC RAT Shs - > Ge i0SSupport @ 2105 2287
+  Library am 2/5/25 SSS
+FILENAME: facetime-call-history
+
+EXAMPLE 5 — Terminal or git commit
+OCR TEXT:
+  V5 feature fix #190 7
+FILENAME: v5-feature-fix-190
+
+=== NOW PROCESS THIS OCR TEXT ===
+
+{ocr_text}
+```

--- a/tools/prompt-screenshot-rename.md
+++ b/tools/prompt-screenshot-rename.md
@@ -1,0 +1,224 @@
+# Screenshot Rename Prompt — For Online Model Testing
+
+Copy the entire fenced block below into any vision-capable model (GPT-4V, Claude
+3.5 Sonnet, Gemini 1.5 Pro, Gemma 4 E2B, Qwen-VL, etc.) along with a screenshot
+image.  The prompt is self-contained — it includes few-shot examples, output
+format instructions, and a taxonomy of common macOS screenshot contexts.
+
+---
+
+## Prompt
+
+```
+You are a filename generator for macOS screenshots.  Your job is to look at a
+screenshot and produce a **very short, descriptive, filesystem-safe filename**
+(3–4 words, kebab-case, lowercase), plus a **context tag** that classifies the
+type of content.
+
+────────────────────────────────────────────────────────────
+RULES
+────────────────────────────────────────────────────────────
+
+1. Output ONLY a JSON object.  No markdown, no backticks, no commentary.
+
+2. The JSON must have exactly two keys:
+
+   "name":  3–4 words, all lowercase, hyphen-separated, no special characters,
+           no extension.  Must be descriptive enough that a human can tell
+           what the screenshot contains without opening it.
+
+   "context":  ONE of the category tags listed in the CONTEXT TAXONOMY below.
+              Pick the single best match.
+
+3. THINK before writing.  Ask yourself:
+
+   a) What kind of app or screen is this?
+   b) What is the main subject or action?
+   c) If it's a conversation (chat, messages, email threads), what is the
+      topic?  Who is talking?  Is it personal, work, or transactional?
+
+   Then condense your answer into the shortest possible name that captures
+   the essence.
+
+4. Prioritise INFORMATION over aesthetics.
+   - "salary-delay-messages"  is better than  "blue-imessage-bubbles"
+   - "customer-onboarding-thread"  is better than  "slack-dark-mode"
+   - "error-build-failed"  is better than  "terminal-red-text"
+
+5. For conversations / messaging screenshots, include the keyword
+   "text_conversation" in your thinking but NOT in the name — it should
+   influence the CONTEXT tag.  If two or more people are exchanging
+   messages, the context is "text_conversation".
+
+────────────────────────────────────────────────────────────
+CONTEXT TAXONOMY  (pick exactly one)
+────────────────────────────────────────────────────────────
+
+text_conversation    Chat, iMessage, Slack, Discord, WhatsApp, email threads,
+                     comment sections — any back-and-forth between people.
+code                 Source code in an editor or IDE (VS Code, Xcode, JetBrains).
+terminal             Command-line terminal, shell output, logs, build output.
+web_browser          A web page in Safari / Chrome / Firefox (not a web app).
+web_app              Gmail, Notion, Figma, Google Docs, Shopify admin — a
+                     complex web application, not a static page.
+settings             System Preferences, Settings app, configuration panels,
+                     preference windows.
+video_call           FaceTime, Zoom, Google Meet, any video-conferencing grid.
+document             PDF, Word, Excel, Preview.app, spreadsheets, presentations.
+social_media         Twitter/X, Instagram, LinkedIn, Reddit, TikTok feed.
+email                Single email composition window (not a thread).
+notification         Notification banner, Notification Centre, alert popup.
+file_explorer        Finder, file picker dialog, folder view.
+error_dialog         Error message, crash report, permission prompt, alert.
+photo                An actual photograph (not a screenshot of UI), camera roll.
+diagram              Flowchart, architecture diagram, mind map, wireframe.
+other                Anything that doesn't fit the above.
+
+────────────────────────────────────────────────────────────
+EXAMPLES  (with thought process)
+────────────────────────────────────────────────────────────
+
+Example 1 — iMessage chat about a delayed salary payment
+  Image: Dark-mode Messages.app showing a conversation between the user
+         and "HR Manager".  Messages discuss salary not arriving,
+         "should hit by Friday", "let me check with payroll".
+  Thought: Two people texting about a delayed salary.  This is a personal /
+           work conversation.  Main topic: salary delay.
+  Output: {"name": "salary-delay-messages", "context": "text_conversation"}
+
+Example 2 — Slack thread about customer onboarding
+  Image: Slack workspace "Acme Corp".  #customer-success channel.
+         Messages discuss a new client "Wayne Enterprises" going through
+         onboarding, "sent them the welcome deck", "demo scheduled for Thu".
+  Thought: Work chat in Slack.  3+ people discussing customer onboarding
+           logistics.  Clear topic: customer onboarding.
+  Output: {"name": "customer-onboarding-thread", "context": "text_conversation"}
+
+Example 3 — VS Code showing a TypeScript React component
+  Image: Dark editor with syntax highlighting.  File tab reads
+         "UserProfile.tsx".  Code includes useState, useEffect, JSX.
+         Sidebar shows file tree with src/components/UserProfile.tsx.
+  Thought: Code editor with a React component file open.
+  Output: {"name": "user-profile-component", "context": "code"}
+
+Example 4 — Terminal with a failing build
+  Image: iTerm2 window.  Output from "npm run build".  Red error text:
+         "Module not found: Can't resolve './utils/formatDate'".
+         Several stack frames below.
+  Thought: Terminal showing a failed build with a module resolution error.
+  Output: {"name": "build-module-not-found", "context": "terminal"}
+
+Example 5 — Safari showing a flight search on Google Flights
+  Image: Google Flights page.  Search: NYC → LAX, Dec 15–22.  Price grid
+         visible.  URL bar shows google.com/travel/flights.
+  Thought: Web browser showing flight search results.  Web page, not a
+           complex app.
+  Output: {"name": "flight-search-results", "context": "web_browser"}
+
+Example 6 — System Settings > Displays
+  Image: macOS System Settings window.  "Displays" selected in sidebar.
+         Resolution options: "Default", "More Space".  Night Shift toggle.
+  Thought: macOS settings panel for display configuration.
+  Output: {"name": "display-settings-panel", "context": "settings"}
+
+Example 7 — FaceTime call with two people
+  Image: FaceTime window.  Two video tiles.  One person in a kitchen,
+         another at a desk.  Mute/camera controls at bottom.
+  Thought: Video call between two people.  No visible conversation topic —
+           can't determine purpose from thumbnail alone.
+  Output: {"name": "two-person-video-call", "context": "video_call"}
+
+Example 8 — Gmail compose window
+  Image: Gmail compose popup in browser.  To: "vendor@supplyco.com".
+         Subject: "PO #4582 – Updated quantities".  Body mentions
+         "attached revised spreadsheet".
+  Thought: Single email being composed (not a thread).  Topic: purchase
+           order update.
+  Output: {"name": "purchase-order-email", "context": "email"}
+
+Example 9 — Finder window showing ~/Desktop
+  Image: Finder window in column view.  Files visible: "Screenshot *.png",
+         "budget-2026.xlsx", "resume-v3.pdf".  Sidebar shows Favourites.
+  Thought: File explorer showing Desktop folder contents.
+  Output: {"name": "desktop-folder-finder", "context": "file_explorer"}
+
+Example 10 — Xcode "Build Failed" error overlay
+  Image: Xcode with a red banner: "Build Failed — 3 errors".  Issue
+          navigator shows "Use of unresolved identifier 'userName'".
+  Thought: IDE showing a build error dialog.  This is primarily an error,
+           even though it's inside a code editor.
+  Output: {"name": "xcode-build-failed", "context": "error_dialog"}
+
+Example 11 — WhatsApp chat with family group
+  Image: WhatsApp "Family ❤️" group.  Messages in Hindi/English mix.
+         Discussing dinner plans, "7 baje?", "haan theek hai",
+         "main pav bhaji la raha".
+  Thought: Family group chat discussing dinner plans.  Casual conversation.
+  Output: {"name": "family-dinner-plans", "context": "text_conversation"}
+
+Example 12 — PDF in Preview.app
+  Image: Preview.app showing a PDF.  Title bar: "Q3-Earnings-Report.pdf".
+         Content shows tables with revenue figures and a bar chart.
+  Thought: PDF document with financial data.  Not a web page — native app.
+  Output: {"name": "q3-earnings-report", "context": "document"}
+
+────────────────────────────────────────────────────────────
+NOW ANALYSE THE ATTACHED SCREENSHOT
+────────────────────────────────────────────────────────────
+
+Look at the image carefully.  Go through the 3 thinking questions above.
+Then output ONLY the JSON object.
+```
+
+---
+
+## How To Test Online
+
+### Option A — OpenAI GPT-4V / GPT-4o (ChatGPT Plus)
+1. Go to https://chat.openai.com
+2. Start a new chat with GPT-4o
+3. Paste the **entire prompt block** above as your message
+4. Attach a screenshot image
+5. Send
+
+### Option B — Google AI Studio (Gemini 1.5 Pro / Flash)
+1. Go to https://aistudio.google.com
+2. Create a new "Freeform" prompt
+3. Set model to "Gemini 1.5 Pro"
+4. Paste the prompt + attach the image
+5. Run
+
+### Option C — Anthropic Console (Claude 3.5 Sonnet)
+1. Go to https://console.anthropic.com
+2. Create a new message
+3. Paste the prompt + attach the image
+4. Run
+
+### Option D — Ollama (local — gemma4:e2b)
+```bash
+ollama run gemma4:e2b
+```
+Then paste the prompt text and provide the image path.
+
+---
+
+## Evaluation Rubric
+
+For each model, score 5 test screenshots (mix of chat, code, web, settings, video):
+
+| Criterion | Weight | What to check |
+|-----------|--------|---------------|
+| **Name accuracy** | 40% | Does the name describe what's actually in the screenshot? |
+| **Name length** | 15% | Is it 3–4 words? (not 1, not 8) |
+| **Context tag** | 20% | Is the taxonomy tag correct? |
+| **Output format** | 10% | Clean JSON? No markdown wrapping? |
+| **Speed** | 15% | How long does inference take? |
+
+Score each criterion 1-5, then compute weighted average.
+
+| Model | Accuracy (×0.4) | Length (×0.15) | Context (×0.2) | Format (×0.1) | Speed (×0.15) | **Total** |
+|-------|-----------------|-----------------|----------------|---------------|---------------|-----------|
+| gpt-4o | | | | | | |
+| claude-3.5-sonnet | | | | | | |
+| gemini-1.5-pro | | | | | | |
+| gemma4:e2b (ollama) | | | | | | |


### PR DESCRIPTION
## Summary

Phase 4 of the [Screenshot Declutterer plan](https://github.com/Collaboration95/screenshot-declutterer/blob/add-llm/docs/design-phase4-polish.md) — hardens the application for daily use with four independent workstreams: memory pruning/GC, dark mode, auto-categorization, and LLM retry/error recovery.

All four workstreams are fully implemented, tested (244 tests, all passing), lint-clean (Ruff), and type-safe (Pyright).

---

## Requirements (from design doc §1)

| # | Workstream | Status |
|---|-----------|--------|
| 4A | Memory pruning / GC | ✅ |
| 4B | Dark mode | ✅ |
| 4C | Auto-categorization (FE-011) | ✅ |
| 4D | LLM retry / error recovery | ✅ |

---

## Changes by File

### `src/ss_dcl/app.py` (+145/-13)

**4A — Memory Pruning:**
- Active-fingerprint tracking in `get_screenshots()` — sources from the *matched* record (not recomputed), so renamed files are correctly kept active
- `prune_stale()` call after every scan with configurable `max_age_days` (default 90)
- `_prune_max_age()` with cache invalidation on `_reset_memory()` and settings save — avoids per-scan `settings.json` I/O on the hot path
- `prune_max_age_days` added to `GET`/`PUT` `/api/settings` endpoints with type validation
- Removed `TODO(phase-1b)` from `api_memory`

**4C — Auto-Categorization:**
- `extract_keywords()` — parses kebab-case LLM output into word tokens
- `suggest_category()` — heuristic that joins `state.json` decisions (filename → keep/trash) to memory record keywords, scoring overlap to suggest a column
- `_read_decisions()` — defensive `state.json` loader (returns `{}` on miss/corruption)
- Wired into `api_suggest_names`: stores `meta.keywords` on every suggestion, sets `meta.suggested_category` when keep/trash signal is strong enough
- `GET /api/screenshots` response now includes `suggested_category` field (additive, nullable)

**4D — LLM Retry:**
- Retry loop in `_call_ollama_suggest`: up to 2 retries with 1s/2s backoff
- Retries only on `URLError`/`OSError` (connection/timeout) — `JSONDecodeError` fails fast (malformed response won't fix itself)
- Per-attempt timeout stays 30s (not 60s) → worst case per file ≈ 93s
- `api_suggest_names` returns `failures` list alongside `suggestions`

### `static/style.css` (+266/-?)

**4B — Dark Mode:**
- `:root` block with ~67 CSS custom property definitions (light defaults)
- `[data-theme="dark"]` block with dark variants respecting macOS system dark palette
- All 123 color literal occurrences replaced with `var(--xxx)` references
- New themed properties: `--bg-body`, `--bg-header`, `--bg-column`, `--bg-card`, `--bg-modal`, `--text-primary`, `--text-secondary`, `--text-muted`, `--border-col`, `--border-header`, `--shadow-card`, `--count-bg`, `--count-keep-bg`, `--count-trash-bg`, `--lightbox-bar-bg`, `--lightbox-backdrop`, and many more

**4B — Theme toggle:**
- `.header-theme-btn` styling matching the settings button
- Icon visibility rules (`[data-theme="dark"] .theme-icon-light { display: none }`)

**4C — Category hints:**
- `.card.category-hint-keep` — green left border accent (themed)
- `.card.category-hint-trash` — red left border accent (themed)

### `static/app.js` (+80/-?)

**4B — Theme management:**
- `THEME_KEY` / `applyTheme()` / `getSavedTheme()` / `saveTheme()` / `cycleTheme()` / `_updateThemeLabel()`
- Auto/dark/light tri-state cycle via `localStorage`
- `matchMedia("(prefers-color-scheme: dark)")` listener for system changes (only active in "auto" mode)
- Dynamic `aria-label` on theme toggle for accessibility

**4A — Settings modal:**
- `#settings-prune-age` input populated from `llmSettings.prune_max_age_days` (default 90)
- Validate and send on save

**4C — Category hints:**
- `makeCard()` accepts `suggestedCategory` parameter, adds `category-hint-keep`/`category-hint-trash` CSS class
- `dataset.suggestedCategory` set from API response

**4D — Failure tracking:**
- `failedCount` accumulator in `suggestBatch()` closure
- Terminal message shows `"Done! N processed — M files failed"` when failures present
- Extended timeout on terminal message (2.5s vs 1.5s) for readability

### `templates/index.html` (+8)

- **4B:** Theme toggle button (`#theme-toggle`) with ☀/☾ icons, placed before settings button
- **4A:** Prune age input field in settings modal (`#settings-prune-age`, type="number", min=1, max=730)

### `tests/test_routes_memory.py` (+457)

**28 new tests (22 backend + 6 frontend):**

**4A — Pruning (8 tests):**
| Test | What it verifies |
|------|-----------------|
| `test_scan_triggers_prune_stale` | Orphaned entries beyond max age are removed |
| `test_prune_respects_settings_age` | Changing `prune_max_age_days` affects what gets pruned |
| `test_prune_keeps_active_entries` | Files still on disk are never pruned |
| `test_prune_keeps_renamed_on_disk` | Renamed files still on disk are treated as active |
| `test_prune_keeps_recent_inactive` | Files trashed 5 days ago kept within 90-day window |
| `test_save_settings_invalidates_prune_cache` | Cache refreshed after settings save |
| `test_settings_prune_age_roundtrip` | Save → load preserves value |
| `test_settings_prune_age_type_validation` | Non-integer values rejected |

**4C — Auto-categorization (8 tests):**
| Test | What it verifies |
|------|-----------------|
| `test_extract_keywords_from_suggested_name` | `"foo-bar-baz.png"` → `["foo", "bar", "baz"]` |
| `test_extract_keywords_filters_short_words` | Words ≤2 chars filtered |
| `test_suggest_category_no_decisions_returns_none` | Empty decisions → None |
| `test_suggest_category_keep_when_keywords_match_kept` | Matching kept files → "keep" |
| `test_suggest_category_trash_when_keywords_match_trashed` | Matching trashed files → "trash" |
| `test_suggest_category_ignores_renamed_but_undecided` | Renamed-but-undecided not a keep signal |
| `test_suggest_category_tie_returns_none` | Equal scores → None |
| `test_suggest_names_stores_keywords_in_meta` | Keywords populated after suggestion |
| `test_screenshots_includes_suggested_category` | Response includes field |

**4D — Retry (6 tests):**
| Test | What it verifies |
|------|-----------------|
| `test_suggest_names_returns_failures_list` | Failures appear in response |
| `test_suggest_names_empty_failures_on_success` | `failures: []` when all succeed |
| `test_call_ollama_suggest_retries_on_url_error` | 3 attempts (initial + 2 retries) |
| `test_call_ollama_suggest_succeeds_on_retry` | Second attempt succeeds |
| `test_call_ollama_suggest_no_retry_on_bad_json` | `JSONDecodeError` fails fast |
| `test_frontend_shows_failure_count` | JS references `failedCount`/`failures` |

**5 existing test assertions** updated to include `"failures": []` in expected response shape.

### `tests/test_frontend.py` (+58)

**4B — Dark mode (4 tests):**
| Test | What it verifies |
|------|-----------------|
| `test_index_has_theme_toggle` | `#theme-toggle` button in HTML |
| `test_app_js_has_theme_cycle` | `THEME_KEY` and `cycleTheme()` in JS |
| `test_css_has_dark_variables` | `[data-theme="dark"]` with `--bg-body` |
| `test_css_has_light_variables` | `:root` with `--bg-body` |

**4C/4D (2 tests):**
| Test | What it verifies |
|------|-----------------|
| `test_css_has_category_hint_styles` | `.category-hint-keep`/`-trash` in CSS |
| `test_app_js_shows_failure_count` | `failedCount`/`failures` in JS |

---

## Design Decisions

1. **Active fingerprints sourced from matched records (not recomputed).** A renamed file has a different `compute_fingerprint()` value than the original memory key. Building `active_fps` from recomputed fingerprints would prune renamed-but-still-on-disk files. Instead, we track the fingerprint of whichever record actually matched — the original-keyed one for renamed files.

2. **Prune age cache invalidated on `_reset_memory()`.** The module-level cache persists between test runs. Invalidating it in `_reset_memory()` (already called by `conftest.py`) prevents cross-test contamination without adding test-only hooks.

3. **Full CSS variable pass (not partial).** The stylesheet had 67 unique color values across 123 occurrences — from `#fff` cards to `rgba(0,0,0,0.55)` lightbox bars. Partial theming (just body/header) looks broken; a complete pass on all 123 references is the right call. Action colors (blue, green, red) are intentionally left hardcoded since macOS system colors work on both light and dark backgrounds.

4. **Theme tri-state cycle (auto → dark → light → auto).** Default "auto" follows the system `prefers-color-scheme`. Two icon states (sun/moon) can't visually distinguish auto-showing-dark from forced-dark — solved with dynamic `aria-label` that includes the effective mode on hover.

5. **Auto-categorization learns from `state.json` decisions, not memory statuses.** Memory statuses are `{new, suggested, renamed, ignored, trashed}` — none of which means "the user kept this file." The correct source of truth is `state.json` `decisions`, keyed by filename. This corrects an earlier draft that used `status == "renamed"` as a keep proxy.

6. **Retry only on transient failures.** `JSONDecodeError` is not retried — a malformed response won't fix itself. `URLError`/`OSError` (connection refused, timeout) get up to 2 retries with exponential backoff (1s, 2s). Per-attempt timeout stays 30s to bound worst-case batch latency.

7. **Cold-start for auto-categorization is explicitly accepted.** Keywords are only attached when a file is LLM-suggested, and the keep/trash join only sees files decided after this feature ships. The hint is inert until enough suggested-then-decided history accumulates — acceptable for a learn-with-use feature.

---

## Testing

- **244 tests pass** (was 216; +28 new tests)
- **No Ollama required** — all LLM calls mocked via `monkeypatch`
- **Settings/prune isolation** — `SETTINGS_FILE` patched to `tmp_path`
- **Lint clean** — Ruff passes
- **Format clean** — `ruff format` passes
- **Type safe** — Pyright passes (0 errors)

---

## How to Test Manually

```bash
# Start the app
uv run python -m src.ss_dcl.app

# Dark mode:
# 1. Click ☀/☾ button in header to cycle themes
# 2. Toggle system appearance (System Settings → Appearance) to test auto mode

# Pruning:
# 1. Open settings (⚙), set "Prune memory after (days)" to 1
# 2. Trash some files, wait a day (or manually backdate memory.json)
# 3. Restart app — orphaned entries should be gone

# Auto-categorization:
# 1. Manually sort some screenshots into Keep/Trash columns
# 2. Use "✨ Suggest All" on new screenshots
# 3. After accepting suggestions, future similar screenshots may show a colored left border hint

# Retry:
# 1. Stop Ollama, trigger "✨ Suggest All"
# 2. Start Ollama during processing — retries should recover
```

---

## Future Work (Phase 5+)

- MLX provider support
- Parallel LLM calls via ThreadPoolExecutor
- "Reset learning data" button for auto-categorization
- High-contrast theme (`[data-theme="high-contrast"]`)
- Accessibility audit (screen reader, keyboard nav)