### PR TITLE
feat(triage): multi-select batch triage, reveal in Finder, empty-column drop hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ tests/test_frontend.py   Frontend integration tests
 | PUT | `/api/state` | Save decisions state |
 | POST | `/api/done` | Trash files — body `{filenames: [...]}`. Updates memory with `trashed` status. Returns 207 on partial failure with per-file errors |
 | POST | `/api/rename` | Rename a file — body `{old_name, new_name}`. Updates state, thumbnail, memory, and clears suggested_category hint. Returns 409 on conflict |
+| POST | `/api/reveal` | Reveal a file in Finder (macOS) — body `{filename}`. Runs `open -R` fire-and-forget; path-traversal guarded. Returns 400 off-macOS, 404 if missing |
 | GET | `/api/memory` | Get all persisted memory records `{files: {fingerprint: {status, suggested_name, last_updated}}}` |
 | POST | `/api/suggest-names` | Generate AI filename suggestions via Ollama — body `{fingerprints: [...]}`. Returns `{suggestions: {fp: name}, failures: [fp]}`. Uses `gemma4:e2b` by default |
 | POST | `/api/accept-suggestion` | Accept suggestion & rename file — body `{fingerprint}`. Handles name conflicts (appends `-2`) |
@@ -61,7 +62,7 @@ All filename-accepting routes validate against path traversal: bare name check (
 
 All in `static/app.js`:
 
-- **Global state**: `decisions` (Map), `undoStack` (Array), `totalCards`, `currentSort`
+- **Global state**: `decisions` (Map), `undoStack` (Array), `selectedCards` (Set), `totalCards`, `currentSort`
 - **Entry**: `init()` → loads saved state → `loadScreenshots()` → creates cards via `makeCard()`
 - **Core logic**: `moveCard(card, column)` updates decisions map, undo stack, DOM, and persists state
 - **Drag-and-drop**: Native HTML5 Drag and Drop API. Cards `draggable="true"`. Columns are drop targets with visual feedback via CSS classes (`dragging`, `drag-over`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Multi-select + batch triage — click cards to select (blue ring + checkmark), floating batch bar moves the whole selection to Keep/Trash, dragging a selected card moves all selected; undo stays per-card (#69)
+- Reveal in Finder — `POST /api/reveal` runs `open -R` on macOS (fire-and-forget, path-traversal guarded); Finder button on card actions and in the lightbox (#71)
+- Empty-column drop hints — faint dashed "Drop here to keep/trash" placeholders inside empty side columns, dark-mode aware (#72)
+
+### Removed
+
+- Keyboard-driven triage (FE-007) removed from the backlog indefinitely
+
 ## [0.4.0] - 2026-08-05
 
 ### Added

--- a/backlog-features.txt
+++ b/backlog-features.txt
@@ -17,10 +17,11 @@ SCOPE EXPANSION
            Currently scans top-level ~/Desktop only. Add option to
            recurse into subdirectories and surface nested screenshots.
 
-[ ] FE-003  Configurable source folders
-           Allow users to configure which directories to scan instead
-           of hardcoding ~/Desktop. Could be a simple settings UI or
-           a config file.
+[ ] FE-003  Tracking folders (configurable source folders)
+           Scan user-chosen directories in addition to ~/Desktop (e.g.
+           ~/Downloads, dev scratch dirs). LOGGED as GitHub issue #70 —
+           spec TBD: folder-picker UI, source tagging on cards, filename
+           collision handling, persistence in settings.json.
 
 
 NEW ACTIONS
@@ -46,10 +47,6 @@ UX IMPROVEMENTS
             Click to edit inline — no modal needed. Reuses existing
             POST /api/rename endpoint. No backend changes required.
             Design doc: docs/design-fe010-inline-rename.md
-
-[ ] FE-007  Keyboard-driven workflow
-           Vim-style keys (j/k to cycle cards, h/l to triage) for
-           fast keyboard-only operation.
 
 [ ] FE-008  Sort and filter by date range, file size, or screen region
            Let users narrow down visible screenshots before sorting.
@@ -104,9 +101,28 @@ QUALITY OF LIFE
            NOTE: Suggest All progress bar shipped in 0.4.0; trash-batch
            progress bar still pending.
 
-[ ] FE-015  Multi-level undo
+[x] FE-015  Multi-level undo (done — undoStack already supports arbitrary
+           depth, persisted in sessionStorage across reloads)
            Extend undo beyond a single level so users can step back
            through their full sorting history.
+
+SPRINT 0.5 — TRIAGE POLISH (shipped)
+--------------------------------------
+
+[x] FE-041  Multi-select + batch triage (done — issue #69)
+           Click cards to select (visual ring + checkmark); a floating
+           batch bar moves the whole selection to Keep/Trash; dragging a
+           selected card moves all selected. Undo stays per-card via the
+           existing multi-level undo stack.
+
+[x] FE-042  Reveal in Finder (done — issue #71)
+           POST /api/reveal runs `open -R` on macOS (fire-and-forget,
+           path-traversal guarded). Finder button on every card action
+           overlay and in the lightbox bar.
+
+[x] FE-043  Empty-column drop hints (done — issue #72)
+           Faint dashed "Drop here to keep/trash" placeholder inside
+           empty side columns. CSS-only, dark-mode aware.
 
 
 FUTURE IDEAS (ideation farm — not yet committed to a release)

--- a/src/ss_dcl/app.py
+++ b/src/ss_dcl/app.py
@@ -5,6 +5,8 @@ import json
 import logging
 import os
 import socket
+import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -55,6 +57,7 @@ MEMORY_FILE = Path.home() / ".ss-dcl" / "memory.json"
 SETTINGS_FILE = Path.home() / ".ss-dcl" / "settings.json"
 DEFAULT_LLM_MODEL = "gemma4:e2b"
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+IS_MACOS = sys.platform == "darwin"
 OLLAMA_HEALTH_TIMEOUT = 3  # seconds
 _OLLAMA_HEALTH_TTL = 5.0  # seconds
 _ollama_health_cache: Optional[tuple[float, bool]] = None
@@ -251,6 +254,32 @@ def api_thumb(filename: str):
     response = make_response(send_file(thumb_path))
     response.headers["Cache-Control"] = "private, max-age=86400"
     return response
+
+
+@app.route("/api/reveal", methods=["POST"])
+def api_reveal():
+    """Reveal a screenshot in Finder (macOS) via `open -R`."""
+    data = request.get_json(silent=True) or {}
+    filename = data.get("filename")
+    if not isinstance(filename, str) or not filename:
+        abort(400)
+    reveal_path = _validate_desktop_path(filename)
+    if reveal_path is None:
+        abort(400)
+    if not reveal_path.exists():
+        abort(404)
+    if not IS_MACOS:
+        return jsonify({"ok": False, "error": "Reveal in Finder is only supported on macOS."}), 400
+    try:
+        subprocess.Popen(
+            ["open", "-R", str(reveal_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        logger.warning("Reveal in Finder failed for %s: %s", filename, exc)
+        return jsonify({"ok": False, "error": "Could not launch Finder."}), 500
+    return jsonify({"ok": True})
 
 
 @app.route("/api/state", methods=["GET"])

--- a/static/app.js
+++ b/static/app.js
@@ -1,5 +1,6 @@
 const decisions = new Map();
 const undoStack = [];
+const selectedCards = new Set();
 let totalCards = 0;
 let currentSort = "date_desc";
 
@@ -59,6 +60,12 @@ const renameCancel  = document.getElementById("rename-cancel");
 const renameConfirm = document.getElementById("rename-confirm");
 const renameError   = document.getElementById("rename-error");
 let renameTarget = null;
+
+const batchBar      = document.getElementById("batch-bar");
+const batchCount    = document.getElementById("batch-count");
+const batchKeepBtn  = document.getElementById("batch-keep-btn");
+const batchTrashBtn = document.getElementById("batch-trash-btn");
+const batchClearBtn = document.getElementById("batch-clear-btn");
 
 const columns = [colTrash, colUnsorted, colKeep];
 
@@ -147,6 +154,7 @@ function init() {
 }
 
 function loadScreenshots(savedDecisions) {
+  clearSelection();
   fetch(`/api/screenshots?sort=${encodeURIComponent(currentSort)}`)
     .then(r => r.json())
     .then(files => {
@@ -197,6 +205,7 @@ init();
 sortSelect.addEventListener("change", () => {
   currentSort = sortSelect.value;
   undoStack.length = 0;
+  clearSelection();
   document.querySelectorAll(".card").forEach(c => c.remove());
   loadScreenshots(Object.fromEntries(decisions));
 });
@@ -263,6 +272,7 @@ function makeCard(filename, column, fingerprint, memoryStatus, suggestedName, su
   attachPreview(card);
   attachKeyboard(card);
   attachTooltip(card);
+  attachSelect(card);
 
   return card;
 }
@@ -313,6 +323,7 @@ function setCardActions(card, column) {
 
   const renameBtn = makeActionBtn("Rename", "btn-rename", () => openRenameModal(card));
   const previewBtn = makeActionBtn("Preview", "btn-preview", () => openLightbox(card));
+  const revealBtn = makeActionBtn("Finder", "btn-reveal", () => revealInFinder(card.dataset.filename));
 
   if (column === "unsorted") {
     const keepBtn = makeActionBtn("\u2190 Keep", "btn-keep", () => moveCard(card, "keep"));
@@ -320,6 +331,7 @@ function setCardActions(card, column) {
     actions.appendChild(keepBtn);
     actions.appendChild(previewBtn);
     actions.appendChild(renameBtn);
+    actions.appendChild(revealBtn);
     actions.appendChild(trashBtn);
 
     // Show "✨ AI Suggest" for unprocessed files
@@ -333,6 +345,7 @@ function setCardActions(card, column) {
     const undoBtn = makeActionBtn("\u21A9 Undo", "btn-undo", () => moveCard(card, "unsorted"));
     actions.appendChild(previewBtn);
     actions.appendChild(renameBtn);
+    actions.appendChild(revealBtn);
     actions.appendChild(undoBtn);
   }
 }
@@ -387,6 +400,7 @@ let draggedCard = null;
 function attachDrag(card) {
   card.addEventListener("dragstart", e => {
     draggedCard = card;
+    _lastDragStart = Date.now();
     card.classList.add("dragging");
     e.dataTransfer.effectAllowed = "move";
     e.dataTransfer.setData("text/plain", card.dataset.filename);
@@ -418,9 +432,62 @@ columns.forEach(col => {
     if (!draggedCard) return;
 
     const targetColumn = col.dataset.column;
-    moveCard(draggedCard, targetColumn);
+    // Dragging a selected card moves the whole selection.
+    if (selectedCards.has(draggedCard)) {
+      batchMove(targetColumn);
+    } else {
+      moveCard(draggedCard, targetColumn);
+    }
   });
 });
+
+// ── Multi-select batch triage ─────────────────────────────────────────────
+// Click a card to toggle its selected state; Keep/Trash buttons (or dragging
+// a selected card) act on the whole selection at once. Each card is moved via
+// moveCard(), so every move still lands on the existing multi-level undo stack.
+let _lastDragStart = 0;
+
+function attachSelect(card) {
+  card.addEventListener("click", () => {
+    if (Date.now() - _lastDragStart < 350) return;
+    toggleSelect(card);
+  });
+}
+
+function toggleSelect(card) {
+  if (selectedCards.has(card)) {
+    selectedCards.delete(card);
+    card.classList.remove("selected");
+  } else {
+    selectedCards.add(card);
+    card.classList.add("selected");
+  }
+  updateBatchBar();
+}
+
+function clearSelection() {
+  selectedCards.forEach(card => card.classList.remove("selected"));
+  selectedCards.clear();
+  updateBatchBar();
+}
+
+function updateBatchBar() {
+  const n = selectedCards.size;
+  batchCount.textContent = n ? `${n} selected` : "0 selected";
+  batchKeepBtn.disabled = n === 0;
+  batchTrashBtn.disabled = n === 0;
+  batchBar.hidden = n === 0;
+}
+
+function batchMove(toColumn) {
+  const cards = [...selectedCards].filter(card => document.contains(card));
+  cards.forEach(card => moveCard(card, toColumn));
+  clearSelection();
+}
+
+batchKeepBtn.addEventListener("click", () => batchMove("keep"));
+batchTrashBtn.addEventListener("click", () => batchMove("trash"));
+batchClearBtn.addEventListener("click", clearSelection);
 
 // ── Preview / Lightbox ───────────────────────────────────────────────────────
 function attachPreview(card) {
@@ -464,6 +531,29 @@ function closeLightbox() {
 
 document.getElementById("lightbox-close").addEventListener("click", closeLightbox);
 document.querySelector(".lightbox-backdrop").addEventListener("click", closeLightbox);
+
+// ── Reveal in Finder ────────────────────────────────────────────────────────
+function revealInFinder(filename) {
+  if (!filename) return;
+  fetch("/api/reveal", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ filename }),
+  })
+    .then(r => r.json())
+    .then(data => {
+      statusMsg.textContent = data.ok
+        ? "Revealed in Finder."
+        : (data.error || "Could not reveal in Finder.");
+    })
+    .catch(() => {
+      statusMsg.textContent = "Network error — could not reveal in Finder.";
+    });
+}
+
+document.getElementById("lightbox-reveal-btn").addEventListener("click", () => {
+  revealInFinder(lightbox.dataset.currentFilename);
+});
 
 // ── Card tooltip ───────────────────────────────────────────────────────────
 function attachTooltip(card) {
@@ -654,6 +744,7 @@ document.addEventListener("keydown", e => {
     if (!confirmModal.hidden) { closeModal(); return; }
     if (!renameModal.hidden) { closeRenameModal(); return; }
     if (!settingsModal.hidden) { closeSettingsModal(); return; }
+    if (selectedCards.size > 0) { clearSelection(); return; }
   }
 
   if ((e.metaKey || e.ctrlKey) && e.key === "z") {
@@ -1137,6 +1228,7 @@ modalConfirm.addEventListener("click", () => {
       });
 
       undoStack.length = 0;
+      clearSelection();
 
       updateCounts();
       saveState();

--- a/static/style.css
+++ b/static/style.css
@@ -379,6 +379,36 @@ header h1 {
   border-radius: 8px;
 }
 
+/* ── Empty-column drop hint ─────────────────────────────── */
+/* Faint dashed placeholder inside a column's card area when it has no cards. */
+.column-cards:empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.column-keep .column-cards:empty::after,
+.column-trash .column-cards:empty::after {
+  content: "";
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border: 2px dashed var(--border-col);
+  border-radius: 10px;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-align: center;
+  padding: 12px;
+  pointer-events: none;
+  box-sizing: border-box;
+}
+
+.column-keep .column-cards:empty::after   { content: "Drop here to keep"; }
+.column-trash .column-cards:empty::after  { content: "Drop here to trash"; }
+
 /* ── Card ────────────────────────────────────────────────── */
 .card {
   position: relative;
@@ -402,6 +432,28 @@ header h1 {
 .card.dragging {
   opacity: 0.5;
   transform: scale(0.96);
+}
+
+/* ── Multi-select state ─────────────────────────────────── */
+.card.selected {
+  box-shadow: 0 0 0 2px #007aff, 0 4px 14px rgba(0, 122, 255, 0.25);
+}
+
+.card.selected::after {
+  content: "\2713";
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #007aff;
+  color: #fff;
+  font-size: 0.8rem;
+  line-height: 22px;
+  text-align: center;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
 }
 
 .card img {
@@ -502,6 +554,14 @@ header h1 {
 
 .btn-rename:hover {
   background: #0062cc;
+}
+
+.btn-reveal {
+  background: rgba(94, 92, 230, 0.9);
+}
+
+.btn-reveal:hover {
+  background: #4745d8;
 }
 
 .btn-suggest {
@@ -777,6 +837,77 @@ header h1 {
   font-size: 1rem;
 }
 
+/* ── Batch action bar (multi-select) ─────────────────────── */
+#batch-bar[hidden] {
+  display: none !important;
+}
+
+#batch-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 500;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  background: var(--bg-modal);
+  border: 1px solid var(--border-col);
+  box-shadow: 0 8px 34px rgba(0, 0, 0, 0.22);
+}
+
+.batch-count {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  margin-right: 4px;
+}
+
+.batch-btn {
+  padding: 8px 18px;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.batch-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.batch-keep {
+  background: #34c759;
+  color: #fff;
+}
+
+.batch-keep:not(:disabled):hover {
+  background: #2db84e;
+}
+
+.batch-trash {
+  background: #ff3b30;
+  color: #fff;
+}
+
+.batch-trash:not(:disabled):hover {
+  background: #e0342a;
+}
+
+.batch-clear {
+  background: var(--bg-btn-cancel);
+  color: var(--text-btn-cancel);
+}
+
+.batch-clear:hover {
+  background: var(--bg-btn-cancel-hover);
+}
+
 /* ── Lightbox ────────────────────────────────────────────── */
 .lightbox[hidden],
 .modal-overlay[hidden] {
@@ -844,6 +975,29 @@ header h1 {
 }
 
 /* ── Lightbox rename bar ────────────────────────────────── */
+.lightbox-bar-top {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.lightbox-reveal-btn {
+  background: var(--lightbox-rename-bg);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: var(--lightbox-filename);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+.lightbox-reveal-btn:hover {
+  background: var(--lightbox-filename-hover);
+}
 .lightbox-bar {
   display: flex;
   flex-direction: column;

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,6 +62,14 @@
     </section>
   </main>
 
+  <!-- Batch action bar (multi-select) -->
+  <div id="batch-bar" class="batch-bar" hidden role="toolbar" aria-label="Batch actions">
+    <span class="batch-count" id="batch-count">0 selected</span>
+    <button class="batch-btn batch-keep" id="batch-keep-btn" disabled>Keep</button>
+    <button class="batch-btn batch-trash" id="batch-trash-btn" disabled>Trash</button>
+    <button class="batch-btn batch-clear" id="batch-clear-btn">Clear</button>
+  </div>
+
   <!-- Card filename tooltip (shared, positioned via JS) -->
   <div id="card-tooltip" class="card-tooltip" aria-hidden="true"></div>
 
@@ -71,7 +79,10 @@
     <div class="lightbox-content">
       <img class="lightbox-img" id="lightbox-img" src="" alt="" decoding="async" />
       <div class="lightbox-bar">
-        <span class="lightbox-filename" id="lightbox-filename" role="button" tabindex="0" aria-label="Click to rename"></span>
+        <div class="lightbox-bar-top">
+          <span class="lightbox-filename" id="lightbox-filename" role="button" tabindex="0" aria-label="Click to rename"></span>
+          <button class="lightbox-reveal-btn" id="lightbox-reveal-btn" type="button" aria-label="Reveal in Finder">Finder</button>
+        </div>
         <input class="lightbox-rename-input" id="lightbox-rename-input" type="text" autocomplete="off" spellcheck="false" hidden aria-label="Rename filename" />
         <p id="lightbox-rename-error" class="lightbox-rename-error" role="alert"></p>
       </div>

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -310,3 +310,64 @@ def test_app_js_shows_failure_count(client):
     assert r.status_code == 200
     assert b"failedCount" in r.data
     assert b"failures" in r.data
+
+
+# ── Sprint: multi-select, reveal in Finder, drop hints ─────────────────────
+
+
+def test_index_has_batch_bar(client):
+    """Multi-select batch bar exists in HTML."""
+    c, _ = client
+    html = c.get("/").data.decode()
+    assert 'id="batch-bar"' in html
+    assert 'id="batch-count"' in html
+    assert 'id="batch-keep-btn"' in html
+    assert 'id="batch-trash-btn"' in html
+    assert 'id="batch-clear-btn"' in html
+
+
+def test_app_js_defines_batch_selection(client):
+    """JS must define selection state and batch-move helpers."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"selectedCards" in r.data
+    assert b"function toggleSelect(" in r.data
+    assert b"function clearSelection(" in r.data
+    assert b"function batchMove(" in r.data
+    assert b"function updateBatchBar(" in r.data
+
+
+def test_app_js_defines_reveal_in_finder(client):
+    """JS must define revealInFinder hitting /api/reveal."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"function revealInFinder(" in r.data
+    assert b"/api/reveal" in r.data
+
+
+def test_index_has_lightbox_reveal_button(client):
+    """Lightbox bar must include a reveal-in-Finder button."""
+    c, _ = client
+    html = c.get("/").data.decode()
+    assert 'id="lightbox-reveal-btn"' in html
+
+
+def test_css_has_batch_bar_and_selection_styles(client):
+    """CSS must style the batch bar and .card.selected."""
+    c, _ = client
+    r = c.get("/static/style.css")
+    assert r.status_code == 200
+    assert b"batch-bar" in r.data
+    assert b"card.selected" in r.data
+
+
+def test_css_has_empty_column_hints(client):
+    """CSS must render dashed drop hints in empty side columns."""
+    c, _ = client
+    r = c.get("/static/style.css")
+    assert r.status_code == 200
+    assert b"column-cards:empty" in r.data
+    assert b"Drop here to keep" in r.data
+    assert b"Drop here to trash" in r.data

--- a/tests/test_routes_reveal.py
+++ b/tests/test_routes_reveal.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+from helpers import _make_png
+
+
+def _screenshot(tmp_path, name="Screenshot 2024-01-01 at 12.00.00 PM.png"):
+    (tmp_path / name).write_bytes(_make_png())
+    return name
+
+
+def test_reveal_valid_filename(client):
+    c, desktop = client
+    name = _screenshot(desktop)
+    with patch("src.ss_dcl.app.subprocess.Popen") as mock_popen:
+        r = c.post("/api/reveal", json={"filename": name})
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+    mock_popen.assert_called_once()
+    args = mock_popen.call_args[0][0]
+    assert args[0] == "open"
+    assert args[1] == "-R"
+    assert args[2] == str(desktop / name)
+
+
+def test_reveal_missing_file_returns_404(client):
+    c, _ = client
+    r = c.post("/api/reveal", json={"filename": "Does Not Exist.png"})
+    assert r.status_code == 404
+
+
+def test_reveal_path_traversal_rejected(client):
+    c, desktop = client
+    _screenshot(desktop)
+    # Bare-name check + resolved-path-within-Desktop guard
+    assert c.post("/api/reveal", json={"filename": "../state.json"}).status_code == 400
+    assert c.post("/api/reveal", json={"filename": "sub/dir.png"}).status_code == 400
+
+
+def test_reveal_rejects_bad_payloads(client):
+    c, desktop = client
+    _screenshot(desktop)
+    assert c.post("/api/reveal", json={"filename": 123}).status_code == 400
+    assert c.post("/api/reveal", json={}).status_code == 400
+
+
+def test_reveal_off_macos_returns_clear_error(client, monkeypatch):
+    c, desktop = client
+    name = _screenshot(desktop)
+    monkeypatch.setattr("src.ss_dcl.app.IS_MACOS", False)
+    with patch("src.ss_dcl.app.subprocess.Popen") as mock_popen:
+        r = c.post("/api/reveal", json={"filename": name})
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["ok"] is False
+    assert "macOS" in body["error"]
+    mock_popen.assert_not_called()


### PR DESCRIPTION
## Sprint: triage polish — multi-select, Reveal in Finder, drop hints

Three small, non-LLM user-facing improvements shipped in one branch (the prior sprint's features are all kept intact; no backend model code touched).

### What's in this PR

| Feature | Issue | Summary |
|---|---|---|
| **Multi-select + batch triage** | Closes #69 | Click a card to select it (blue ring + checkmark). A floating **batch bar** appears with Keep / Trash / Clear and moves the whole selection at once. Dragging a *selected* card onto a column moves everything selected. Every move still goes through `moveCard()`, so **per-card undo keeps working**. Selection clears on Escape, re-sort, and after "Done". |
| **Reveal in Finder** | Closes #71 | New `POST /api/reveal` runs `open -R <path>` on macOS (fire-and-forget `subprocess.Popen`, guarded by the existing two-layer path-traversal check, `404` if missing, clear error off-macOS via `IS_MACOS`). **Finder** button added to every card's action overlay + the lightbox bar; failures surface in the status area. |
| **Empty-column drop hints** | Closes #72 | Empty Keep/Trash columns now show a faint dashed placeholder ("Drop here to keep/trash"), CSS-only via `.column-cards:empty::after`, themed for dark mode. Drag-over highlight still wins during a drag. |
| **Tracking folders** | References #70 | **Log-only feature request** — scan user-chosen folders alongside `~/Desktop`. Spec (picker UI, source tags, name collisions) deliberately deferred to the next sprint; no implementation here. |
| **Backlog housekeeping** | — | Removed keyboard triage (FE-007) indefinitely; marked FE-015 (multi-level undo) as shipped since `undoStack` already supports arbitrary depth. |

### Verification
- `ruff check` — clean
- `ruff format --check` — clean
- `pyright` — 0 errors
- `pytest` — **267 passed** (new `tests/test_routes_reveal.py` + frontend markup assertions for the batch bar, reveal, and drop hints)
- Pre-commit hooks all passed on commit

### Out of scope (intentionally)
- LLM / OCR work (back burner, as agreed)
- Tracking folders (#70) implementation — logged only