### PR TITLE
feat(ui): Photos-style batch drag ghost + persistent batch selection (#74, #76)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ All in `static/app.js`:
 - **Global state**: `decisions` (Map), `undoStack` (Array), `selectedCards` (Set), `totalCards`, `currentSort`
 - **Entry**: `init()` → loads saved state → `loadScreenshots()` → creates cards via `makeCard()`
 - **Core logic**: `moveCard(card, column)` updates decisions map, undo stack, DOM, and persists state
-- **Drag-and-drop**: Native HTML5 Drag and Drop API. Cards `draggable="true"`. Columns are drop targets with visual feedback via CSS classes (`dragging`, `drag-over`)
+- **Drag-and-drop**: Native HTML5 Drag and Drop API. Cards `draggable="true"`. Columns are drop targets with visual feedback via CSS classes (`dragging`, `drag-over`). Dragging a selected card attaches a Photos-style fanned stack of the whole selection to the cursor (`buildBatchDragGhost()` — composite canvas + `setDragImage`); visual only, drop still batch-moves
 - **Kanban layout**: Three columns — Keep (22% width), Unsorted (CSS Grid, flex:1), Trash (22% width)
 - **Undo**: `performUndo()` pops from stack, reverses the move
 - **Lightbox**: Double-click or Preview button → full-size overlay. Escape or backdrop click closes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-select + batch triage — click cards to select (blue ring + checkmark), floating batch bar moves the whole selection to Keep/Trash, dragging a selected card moves all selected; undo stays per-card (#69)
 - Reveal in Finder — `POST /api/reveal` runs `open -R` on macOS (fire-and-forget, path-traversal guarded); Finder button on card actions and in the lightbox (#71)
 - Empty-column drop hints — faint dashed "Drop here to keep/trash" placeholders inside empty side columns, dark-mode aware (#72)
+- Photos-style batch drag ghost — dragging a selected card fans the selection's thumbnails out on the cursor (composite canvas + `setDragImage`, capped at 6 tiles with a `+N` badge), visual only (#74)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keyboard-driven triage (FE-007) removed from the backlog indefinitely
 
+### Fixed
+
+- Batch selection now survives drag-and-drop and batch Keep/Trash — the moved cards stay selected until the user explicitly deselects (Escape / ✕ / re-sort / Done) (#76)
+
 ## [0.4.0] - 2026-08-05
 
 ### Added

--- a/backlog-features.txt
+++ b/backlog-features.txt
@@ -251,11 +251,10 @@ ENGINEERING & HARDENING
            Local-first means no telemetry by default. Optional, anonymous,
            clearly-documented toggle — only if the user base justifies it.
 
-[ ] FE-044  Photos-style batch drag preview (#74)                      [P2][S]
-           When dragging a selected card, show a fanned stack of the
-           selected thumbnails on the cursor (rotated, overlapping,
-           count badge when >6) via a composite canvas + setDragImage.
-           Purely visual — drop/undo/batch logic unchanged.
+[x] FE-044  Photos-style batch drag preview (#74)                      [P2][S]
+           Done — dragging a selected card fans the selected thumbnails out
+           on the cursor (rotated, overlapping, count badge when >6) via a
+           composite canvas + setDragImage. Visual only — drop logic intact.
 
 
 PARKED / PROBABLY NOT

--- a/static/app.js
+++ b/static/app.js
@@ -404,12 +404,23 @@ function attachDrag(card) {
     card.classList.add("dragging");
     e.dataTransfer.effectAllowed = "move";
     e.dataTransfer.setData("text/plain", card.dataset.filename);
+    // Dragging a selected card: attach a Photos-style fanned stack of the
+    // whole selection to the cursor (visual only — the drop still batchMoves).
+    _clearGhostCanvas();
+    if (selectedCards.has(card) && selectedCards.size > 1) {
+      const ghost = buildBatchDragGhost([...selectedCards], selectedCards.size);
+      if (ghost) {
+        _ghostCanvas = ghost.canvas;
+        e.dataTransfer.setDragImage(ghost.canvas, ghost.offsetX, ghost.offsetY);
+      }
+    }
   });
 
   card.addEventListener("dragend", () => {
     card.classList.remove("dragging");
     draggedCard = null;
     columns.forEach(c => c.classList.remove("drag-over"));
+    _clearGhostCanvas();
   });
 }
 
@@ -488,6 +499,143 @@ function batchMove(toColumn) {
 batchKeepBtn.addEventListener("click", () => batchMove("keep"));
 batchTrashBtn.addEventListener("click", () => batchMove("trash"));
 batchClearBtn.addEventListener("click", clearSelection);
+
+// ── Batch drag ghost (Photos-style) ─────────────────────────────────────────
+// When a drag starts on a selected card, fan the selected thumbnails out on
+// the cursor like the macOS Photos app. HTML5 DnD only supports ONE drag
+// image (setDragImage), so we composite the whole fanned stack onto a single
+// canvas. Purely visual — drop/undo/batch logic is untouched.
+const MAX_GHOST_TILES = 6;
+const GHOST_TILE_W = 168; // 4:3, matches the thumbnail ratio (2×)
+const GHOST_TILE_H = 126;
+
+// Deterministic fan layout: outer tiles tilt away from the middle card, which
+// stays straight-on as the "front" of the stack. Pure function → testable.
+function batchFanLayout(tileCount) {
+  const layout = [];
+  const mid = (tileCount - 1) / 2;
+  for (let i = 0; i < tileCount; i++) {
+    layout.push({
+      dx: Math.round((i - mid) * 18),
+      dy: Math.round(Math.abs(i - mid) * -5),
+      rot: Math.round((i - mid) * 7),
+    });
+  }
+  return layout;
+}
+
+function ghostRoundedRect(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.arcTo(x + w, y, x + w, y + r, r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+  ctx.lineTo(x + r, y + h);
+  ctx.arcTo(x, y + h, x, y + h - r, r);
+  ctx.lineTo(x, y + r);
+  ctx.arcTo(x, y, x + r, y, r);
+  ctx.closePath();
+}
+
+// Composite the selected thumbnails into one fanned-stack canvas. Returns
+// { canvas, offsetX, offsetY } for setDragImage, or null to keep the native
+// ghost (e.g. no thumbnails decoded yet). cards = selected card elements in
+// DOM order; total = number of cards in the selection (may exceed tiles).
+let _ghostCanvas = null; // composite canvas currently attached for drag image
+
+function _clearGhostCanvas() {
+  if (_ghostCanvas) {
+    _ghostCanvas.remove();
+    _ghostCanvas = null;
+  }
+}
+
+function buildBatchDragGhost(cards, total) {
+  // Every card has an <img>; decoding state doesn't matter — drawImage on an
+  // undecoded image simply paints nothing for that slot (graceful degrade).
+  const drawable = cards.filter(card => card.querySelector("img"));
+  if (drawable.length === 0) return null; // nothing usable — native ghost is fine
+  const tileCount = Math.min(drawable.length, MAX_GHOST_TILES);
+  const layout = batchFanLayout(tileCount);
+
+  // Canvas size: fan extent + rotation slack, so rotated corners never clip.
+  const maxRot = Math.max(...layout.map(t => Math.abs(t.rot))) * (Math.PI / 180);
+  const dxMax = Math.max(...layout.map(t => Math.abs(t.dx)));
+  const dyMax = Math.max(...layout.map(t => Math.abs(t.dy)));
+  const extW = GHOST_TILE_W / 2 + (GHOST_TILE_H / 2) * Math.sin(maxRot);
+  const extH = GHOST_TILE_H / 2 + (GHOST_TILE_W / 2) * Math.sin(maxRot);
+  const half = Math.ceil(Math.max(dxMax + extW, dyMax + extH) + 8);
+  const size = half * 2;
+  const dpr = Math.min(window.devicePixelRatio || 1, 3);
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.ceil(size * dpr);
+  canvas.height = Math.ceil(size * dpr);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.scale(dpr, dpr);
+  ctx.translate(half, half); // fan center = drag hotspot later
+
+  // Draw most-tilted tiles first so the straight-on "front" card is on top.
+  const order = [...layout.keys()].sort(
+    (a, b) => Math.abs(layout[b].rot) - Math.abs(layout[a].rot)
+  );
+  for (const i of order) {
+    const img = drawable[i].querySelector("img");
+    const t = layout[i];
+    ctx.save();
+    ctx.translate(t.dx, t.dy);
+    ctx.rotate((t.rot * Math.PI) / 180);
+    ghostRoundedRect(ctx, -GHOST_TILE_W / 2, -GHOST_TILE_H / 2, GHOST_TILE_W, GHOST_TILE_H, 8);
+    ctx.fillStyle = "#fff";
+    ctx.fill();
+    ctx.save();
+    ctx.clip();
+    ctx.drawImage(img, -GHOST_TILE_W / 2, -GHOST_TILE_H / 2, GHOST_TILE_W, GHOST_TILE_H);
+    ctx.restore();
+    ghostRoundedRect(ctx, -GHOST_TILE_W / 2, -GHOST_TILE_H / 2, GHOST_TILE_W, GHOST_TILE_H, 8);
+    ctx.strokeStyle = "rgba(30, 30, 30, 0.25)";
+    ctx.lineWidth = 1;
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // Count badge: "+N" when the selection exceeds the rendered tiles (or some
+  // thumbnails weren't decoded yet).
+  if (total > tileCount) {
+    const label = "+" + (total - tileCount);
+    ctx.font = "600 16px -apple-system, system-ui, sans-serif";
+    const tw = ctx.measureText(label).width;
+    const bw = tw + 18;
+    const bh = 24;
+    const bx = -GHOST_TILE_W / 2 + 10;
+    const by = GHOST_TILE_H / 2 - 26;
+    ghostRoundedRect(ctx, bx, by, bw, bh, bh / 2);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.96)";
+    ctx.fill();
+    ctx.fillStyle = "#1c1c1e";
+    ctx.textBaseline = "middle";
+    ctx.fillText(label, bx + 10, by + bh / 2 + 0.5);
+  }
+
+  // Chrome only rasterizes a drag image if the canvas has already been
+  // PAINTED — an unpainted canvas makes setDragImage fall back to the
+  // browser's blank icon (that little "globe") instead of the stack. So
+  // attach the canvas to the document offscreen (invisible but rendered)
+  // and force layout BEFORE setDragImage; _clearGhostCanvas() removes it
+  // again on dragend.
+  canvas.style.cssText =
+    "position:fixed;top:0;left:0;width:" + size + "px;height:" + size + "px;" +
+    "opacity:0.002;pointer-events:none;";
+  document.body.appendChild(canvas);
+  canvas.getBoundingClientRect(); // force layout → rasterize the bitmap now
+  try {
+    ctx.getImageData(0, 0, 1, 1); // defensive: synchronously commit the bitmap
+  } catch (_) {/* non-2d / tainted — ignore */}
+
+  // Hotspot = center of the front card (canvas center in CSS pixels).
+  return { canvas, offsetX: half, offsetY: half };
+}
 
 // ── Preview / Lightbox ───────────────────────────────────────────────────────
 function attachPreview(card) {

--- a/static/app.js
+++ b/static/app.js
@@ -510,18 +510,20 @@ batchClearBtn.addEventListener("click", clearSelection);
 // image (setDragImage), so we composite the whole fanned stack onto a single
 // canvas. Purely visual — drop/undo/batch logic is untouched.
 const MAX_GHOST_TILES = 6;
-const GHOST_TILE_W = 168; // 4:3, matches the thumbnail ratio (2×)
-const GHOST_TILE_H = 126;
+const GHOST_TILE_W = 252; // 4:3, matches the thumbnail ratio (1.5× of 168)
+const GHOST_TILE_H = 189;
 
-// Deterministic fan layout: outer tiles tilt away from the middle card, which
+// Deterministic fan layout: tiles tilt away from the middle card, which
 // stays straight-on as the "front" of the stack. Pure function → testable.
+// Horizontal/vertical stagger scales with tile size so the fan stays legible
+// at any tile size.
 function batchFanLayout(tileCount) {
   const layout = [];
   const mid = (tileCount - 1) / 2;
   for (let i = 0; i < tileCount; i++) {
     layout.push({
-      dx: Math.round((i - mid) * 18),
-      dy: Math.round(Math.abs(i - mid) * -5),
+      dx: Math.round((i - mid) * (GHOST_TILE_W * 0.112)), // ≈28px @ 252px tiles
+      dy: Math.round(Math.abs(i - mid) * -(GHOST_TILE_H * 0.042)), // ≈ -8px
       rot: Math.round((i - mid) * 7),
     });
   }

--- a/static/app.js
+++ b/static/app.js
@@ -493,7 +493,11 @@ function updateBatchBar() {
 function batchMove(toColumn) {
   const cards = [...selectedCards].filter(card => document.contains(card));
   cards.forEach(card => moveCard(card, toColumn));
-  clearSelection();
+  // Keep the selection after the move: dropping (or clicking Keep/Trash)
+  // should NOT deselect the batch — the user can keep re-dragging/re-
+  // triaging the same set. Deselection is explicit: Escape, the ✕ Clear
+  // button, re-sort, or Done (#76). moveCard() moves the same DOM node,
+  // so selectedCards stays valid.
 }
 
 batchKeepBtn.addEventListener("click", () => batchMove("keep"));

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -338,6 +338,34 @@ def test_app_js_defines_batch_selection(client):
     assert b"function updateBatchBar(" in r.data
 
 
+def test_app_js_defines_batch_drag_ghost(client):
+    """Photos-style composite drag ghost must exist and attach via setDragImage."""
+    c, _ = client
+    r = c.get("/static/app.js")
+    assert r.status_code == 200
+    assert b"MAX_GHOST_TILES" in r.data
+    assert b"function batchFanLayout(" in r.data
+    assert b"function buildBatchDragGhost(" in r.data
+    assert b"setDragImage" in r.data
+    # ghost must only kick in when dragging a *selected* card
+    assert b"selectedCards.has(card)" in r.data
+    assert b"selectedCards.size > 1" in r.data
+
+
+def test_batch_fan_layout_is_symmetric_and_centered():
+    """batchFanLayout exposes pure geometry: middle tile center, symmetric."""
+    import re
+
+    with open("static/app.js", encoding="utf-8") as f:
+        src = f.read()
+    m = re.search(r"function batchFanLayout\(tileCount\) \{.*?\n\}", src, re.S)
+    assert m is not None
+    body = m.group(0)
+    # dy arcs upward (negative excursions ok), rotation symmetric around mid
+    assert "tileCount - 1" in body and "Math.abs(i - mid) * -5" in body
+    assert "(i - mid) * 7" in body
+
+
 def test_app_js_defines_reveal_in_finder(client):
     """JS must define revealInFinder hitting /api/reveal."""
     c, _ = client

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -338,6 +338,23 @@ def test_app_js_defines_batch_selection(client):
     assert b"function updateBatchBar(" in r.data
 
 
+def test_batch_move_preserves_selection():
+    """batchMove must NOT clear the selection — dropping a multi-drag (or
+    clicking batch Keep/Trash) keeps the set selected; deselection is only
+    explicit (Escape / ✕ Clear / re-sort / Done), per issue #76."""
+    import re
+
+    with open("static/app.js", encoding="utf-8") as f:
+        src = f.read()
+    m = re.search(r"function batchMove\(toColumn\) \{.*?\n\}", src, re.S)
+    assert m is not None, "batchMove not found in app.js"
+    body = m.group(0)
+    assert "clearSelection" not in body
+    # still moves every selected card, filtering out stale nodes
+    assert "cards.forEach(card => moveCard(card, toColumn))" in body
+    assert "document.contains(card)" in body
+
+
 def test_app_js_defines_batch_drag_ghost(client):
     """Photos-style composite drag ghost must exist and attach via setDragImage."""
     c, _ = client

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -378,8 +378,9 @@ def test_batch_fan_layout_is_symmetric_and_centered():
     m = re.search(r"function batchFanLayout\(tileCount\) \{.*?\n\}", src, re.S)
     assert m is not None
     body = m.group(0)
-    # dy arcs upward (negative excursions ok), rotation symmetric around mid
-    assert "tileCount - 1" in body and "Math.abs(i - mid) * -5" in body
+    # stagger scales with tile size (so the fan stays legible when resized),
+    # rotation symmetric around mid
+    assert "tileCount - 1" in body and "GHOST_TILE_H * 0.042" in body
     assert "(i - mid) * 7" in body
 
 


### PR DESCRIPTION
## Photos-style batch drag ghost — closes #74 · selection persists after drop — closes #76

Two tightly-coupled UX fixes for batch triage, one branch:

### 1. Photos-style batch drag ghost (#74)
Dragging a selected card **fans the whole selection's thumbnails onto the cursor**, like the macOS Photos app. Composite canvas → `setDragImage`, 2× tiles (168×126) with a `+N` badge past 6 selected.

- `batchFanLayout()` — pure fan geometry: middle card straight-on (drag hotspot), ±7°/tile
- `buildBatchDragGhost()` — composites up to 6 real thumbs; rounded corners + frame
- **Chrome paint fix** — the canvas is attached to the DOM (offscreen, invisible), layout + bitmap forced **before** `setDragImage`; otherwise Chrome falls back to a blank "globe" icon; removed on `dragend`
- Graceful on `decoding="async"` thumbs (skip the slot, never a blank canvas); single-card drags keep the native ghost

### 2. Batch selection survives after drag-and-drop (#76)
Previously `batchMove()` called `clearSelection()` right after a drop, so the 3 cards you just picked vanished the moment you released. Now the selection **persists** — the blue rings + count bar stay, and you can keep re-dragging/triaging the same set. Deselecting stays explicit: **Escape, ✕ Clear, re-sort, or Done**. `moveCard()` moves the same DOM node so `selectedCards` stays valid — zero re-selection bookkeeping.

### Verification
- Manually confirmed: select 3 → drag → drop → still selected; re-drag works; Escape/Clear still deselect
- `node --check` clean, **270 pytest tests pass** (incl. String-level `test_batch_move_preserves_selection`), ruff + pyright clean
- Pre-commit hooks green

### Scope
- Frontend-only (`static/app.js`) — no API/backend changes; drop semantics, undo stack, and batch bar logic intact
- Tile size knob: `const GHOST_TILE_W/H = 168/126` in `static/app.js`